### PR TITLE
feat: add possibility to define CFs in config file as yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Possible ideas:
 - Include own defined custom formats
 - Custom defined formats for different languages/countries like Germany
 - Support all CustomFormat specifications
-- Maybe this?: https://github.com/recyclarr/recyclarr/issues/225
+- Provide CFs in different ways
+  - Sync from TrashGuide
+  - Sync with local file CFs
+  - Provide CFs directly in config (Convert JSON with https://www.bairesdev.com/tools/json2yaml/)
+  - Merge order is `TrashGuide -> LocalFiles -> CFs in Config`
 
 ## Work TODOs
 

--- a/examples/full/config/config.yml
+++ b/examples/full/config/config.yml
@@ -3,6 +3,21 @@
 localCustomFormatsPath: /app/cfs
 localConfigTemplatesPath: /app/templates
 
+customFormatDefinitions:
+  - trash_id: example-in-config-cf
+    trash_scores:
+      default: -10000
+    trash_description: "Language: German Only"
+    name: "Language: Not German"
+    includeCustomFormatWhenRenaming: false
+    specifications:
+      - name: Not German Language
+        implementation: LanguageSpecification
+        negate: true
+        required: false
+        fields:
+          value: 4
+
 sonarr:
   instance1:
     # Set the URL/API Key to your actual instance

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,14 @@ import fs from "fs";
 import { CustomFormatResource } from "./src/__generated__/generated-sonarr-api";
 import { configureRadarrApi, configureSonarrApi, getArrApi, unsetApi } from "./src/api";
 import { getConfig } from "./src/config";
-import { calculateCFsToManage, loadLocalCfs, loadServerCustomFormats, manageCf, mergeCfSources } from "./src/custom-formats";
+import {
+  calculateCFsToManage,
+  loadCFFromConfig,
+  loadLocalCfs,
+  loadServerCustomFormats,
+  manageCf,
+  mergeCfSources,
+} from "./src/custom-formats";
 import { logHeading, logger } from "./src/logger";
 import { calculateQualityDefinitionDiff, loadQualityDefinitionFromServer } from "./src/quality-definitions";
 import {
@@ -95,9 +102,10 @@ const pipeline = async (value: YamlConfigInstance, arrType: ArrType) => {
 
   recylarrMergedTemplates.quality_profiles = filterInvalidQualityProfiles(recylarrMergedTemplates.quality_profiles);
 
-  const result = await loadLocalCfs();
   const trashCFs = await loadSonarrTrashCFs(arrType);
-  const mergedCFs = mergeCfSources([trashCFs, result]);
+  const localFileCFs = await loadLocalCfs();
+  const configCFDefinition = loadCFFromConfig();
+  const mergedCFs = mergeCfSources([trashCFs, localFileCFs, configCFDefinition]);
 
   const idsToManage = calculateCFsToManage(recylarrMergedTemplates);
 

--- a/src/custom-formats.ts
+++ b/src/custom-formats.ts
@@ -136,6 +136,38 @@ export const loadLocalCfs = async (): Promise<CFProcessing | null> => {
     cfNameToCarrConfig: cfNameToCarrObject,
   };
 };
+
+export const loadCFFromConfig = (): CFProcessing | null => {
+  // TODO typings
+  const defs = getConfig().customFormatDefinitions;
+
+  if (defs == null) {
+    logger.debug(`No CustomFormat definitions defined.`);
+    return null;
+  }
+
+  const carrIdToObject = new Map<string, { carrConfig: ConfigarrCF; requestConfig: CustomFormatResource }>();
+  const cfNameToCarrObject = new Map<string, ConfigarrCF>();
+
+  for (const def of defs) {
+    const cfD = toCarrCF(def);
+
+    carrIdToObject.set(cfD.configarr_id, {
+      carrConfig: cfD,
+      requestConfig: mapImportCfToRequestCf(cfD),
+    });
+
+    if (cfD.name) {
+      cfNameToCarrObject.set(cfD.name, cfD);
+    }
+  }
+
+  return {
+    carrIdMapping: carrIdToObject,
+    cfNameToCarrConfig: cfNameToCarrObject,
+  };
+};
+
 export const calculateCFsToManage = (yaml: YamlInput) => {
   const cfTrashToManage: Set<string> = new Set();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,8 @@ export type YamlConfig = {
   recyclarrRevision?: string;
   localCustomFormatsPath?: string;
   localConfigTemplatesPath?: string;
+  customFormatDefinitions?: [];
+
   sonarr: {
     [key: string]: YamlConfigInstance;
   };


### PR DESCRIPTION
Provides a full chain of merge order from trash to granularly defined CF.

Related to https://github.com/recyclarr/recyclarr/issues/218