### PR TITLE
fix: correctly import quality size / definitions from trash github

### DIFF
--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -161,7 +161,7 @@ export const loadTrashCustomFormatGroups = async (arrType: TrashArrSupported): P
 };
 
 export const loadQualityDefinitionFromTrash = async (
-  qdType: QualityDefinitionsSonarr | QualityDefinitionsRadarr,
+  qdType: string, // QualityDefinitionsSonarr | QualityDefinitionsRadarr,
   arrType: TrashArrSupported,
 ): Promise<TrashQualityDefinition> => {
   let trashPath = arrType === "RADARR" ? trashRepoPaths.radarrQualitySize : trashRepoPaths.sonarrQualitySize;
@@ -173,18 +173,14 @@ export const loadQualityDefinitionFromTrash = async (
     }
   }
 
-  switch (qdType) {
-    case "anime":
-      return loadJsonFile(path.resolve(`${trashPath}/anime.json`));
-    case "series":
-      return loadJsonFile(path.resolve(`${trashPath}/series.json`));
-    case "movie":
-      return loadJsonFile(path.resolve(`${trashPath}/movie.json`));
-    case "custom":
-      throw new Error(`(${arrType}) Not implemented yet`);
-    default:
-      throw new Error(`(${arrType}) Unknown QualityDefinition type: ${qdType}`);
+  // TODO: custom quality definition not implemented yet. Not sure if we need to implement this. Qualities can already be defined separately.
+  const filePath = path.resolve(`${trashPath}/${qdType}.json`);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`(${arrType}) QualityDefinition type not found: '${qdType}' for '${arrType}'`);
   }
+
+  return loadJsonFile(filePath);
 };
 
 export const loadQPFromTrash = async (arrType: TrashArrSupported) => {

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -81,7 +81,7 @@ export type MappedTemplates = Partial<
 
 export type MappedMergedTemplates = MappedTemplates & Required<Pick<MappedTemplates, "custom_formats" | "quality_profiles">>;
 
-const ArrTypeConst = ["RADARR", "SONARR", "WHISPARR", "READARR", "LIDARR"] as const;
+export const ArrTypeConst = ["RADARR", "SONARR", "WHISPARR", "READARR", "LIDARR"] as const;
 export type ArrType = (typeof ArrTypeConst)[number];
 
 export type QualityDefinitionsSonarr = "anime" | "series" | "custom";

--- a/src/types/trashguide.types.ts
+++ b/src/types/trashguide.types.ts
@@ -1,4 +1,4 @@
-import { ArrType, CFIDToConfigGroup, ImportCF } from "./common.types";
+import { ArrType, ArrTypeConst, CFIDToConfigGroup, ImportCF } from "./common.types";
 
 export type TrashQualityDefinitionQuality = {
   quality: string;
@@ -60,7 +60,8 @@ export type TrashQP = {
 
 export type TrashCFSpF = { min: number; max: number; exceptLanguage: boolean; value: any };
 
-export type TrashArrSupported = Subset<ArrType, "RADARR" | "SONARR">;
+export const TrashArrSupportedConst = ["RADARR", "SONARR"] as const satisfies readonly ArrType[];
+export type TrashArrSupported = (typeof TrashArrSupportedConst)[number];
 
 export type TrashRadarrNaming = {
   folder: {

--- a/src/util.ts
+++ b/src/util.ts
@@ -315,3 +315,11 @@ export const roundToDecimal = (num: number, decimalPlaces = 0) => {
   const p = Math.pow(10, decimalPlaces);
   return Math.round((num + Number.EPSILON) * p) / p;
 };
+
+export function pickFromConst<T extends readonly string[], K extends T[number]>(constArray: T, keys: readonly K[]): readonly K[] {
+  return keys.filter((key): key is K => constArray.includes(key));
+}
+
+export function isInConstArray<T extends readonly unknown[]>(array: T, value: unknown): value is T[number] {
+  return array.includes(value as T[number]);
+}


### PR DESCRIPTION
fixes #250
Import available quality sizes based on arr in TRaSH-Guide Github.
Previously only statically files could be used and now every (example SQP) are usable and future additions.