### PR TITLE
chore: use trailing slashes for docs URLs

### DIFF
--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -27,7 +27,7 @@ Configarr is a powerful configuration and synchronization tool designed specific
 
 ### Experimental support
 
-Experimental support also available for [(check experimental support)](./configuration/experimental-support):
+Experimental support also available for [(check experimental support)](./configuration/experimental-support.md):
 
 - Whisparr v3
 - Readarr v1
@@ -59,15 +59,15 @@ If you're managing a media server with Sonarr and Radarr (or other \*Arr tools),
 
 - Sonarr v4
 - Radarr v5
-- check experimental support [here](./configuration/experimental-support)
+- check experimental support [here](./configuration/experimental-support.md)
 - Docker or Kubernetes
 
 ## Getting Started
 
 Ready to streamline your media server configuration? Let's get started with the basic setup.
 
-- [Continue to Installation →](./category/installation)
-- [HowTo Configuration →](./examples)
+- [Continue to Installation →](/docs/category/installation/)
+- [HowTo Configuration →](./examples.md)
 - **[YouTube Setup Guide](https://www.youtube.com/watch?v=LoeCXCB89h0)**
   :::note
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -186,6 +186,9 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
     },
   } satisfies Preset.ThemeConfig,
+
+  // use trailing slashes as github pages uses them, this also fixes the sitemap.xml
+  trailingSlash: true,
 };
 
 export default config;


### PR DESCRIPTION
Github pages redirects the paths to trailing slashes. The current setup without trailing slashes might also be a problem for google search indexing.