### PR TITLE
feat: include all relevant CF-Groups (and marked CFs) for TRaSH-Guide…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": ["Bash(pnpm test:*)"],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -45,6 +45,11 @@ Configarr supports two types of templates:
    - `language` field support added with `1.7.0`
    - Can be overridden using `trashGuideUrl` in config.yml
    - See [TRaSH-Guides Radarr](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/radarr/quality-profiles) and [TRaSH-Guides Sonarr](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/sonarr/quality-profiles) for more information
+   - You must also check all CF-Groups because they will be also included automatically (this is desired by the TRaSH-Guide)
+     - [TRaSH-Guides Radarr CF Groups](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/radarr/cf-groups)
+     - [TRaSH-Guides Sonarr CF Groups](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/sonarr/cf-groups)
+     - [Github PR/Explanation](https://github.com/TRaSH-Guides/Guides/pull/2455#discussion_r2297832409)
+     - [Discord Discussion/Explanation](https://discord.com/channels/492590071455940612/1409911784386596894)
 
 ## Configuration Files Reference
 

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { loadQPFromTrash, transformTrashCFGroups, transformTrashQDs } from "./trash-guide";
+import { loadQPFromTrash, transformTrashCFGroups, transformTrashQDs, transformTrashQPCFGroups } from "./trash-guide";
 import { InputConfigCustomFormatGroup } from "./types/config.types";
-import { TrashCFGroupMapping, TrashQualityDefinition } from "./types/trashguide.types";
+import { TrashCFGroupMapping, TrashQualityDefinition, TrashQP } from "./types/trashguide.types";
 
 describe("TrashGuide", async () => {
   test("loadQPFromTrash - normal", async ({}) => {
@@ -132,5 +132,181 @@ describe("TrashGuide", async () => {
     const result = transformTrashCFGroups(mapping, groups);
 
     expect(result).toHaveLength(0);
+  });
+
+  describe("transformTrashQPCFGroups", () => {
+    const mockTrashQP: TrashQP = {
+      trash_id: "profile123",
+      name: "Test Profile",
+      trash_score_set: "default",
+      upgradeAllowed: true,
+      cutoff: "HD",
+      minFormatScore: 0,
+      cutoffFormatScore: 100,
+      items: [],
+      formatItems: {},
+    };
+
+    test("should include CFs from default groups with required=true", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Default Group 1",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [
+          { name: "cf1", trash_id: "cf1", required: true },
+          { name: "cf2", trash_id: "cf2", required: false },
+        ],
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.trash_ids).toEqual(["cf1"]);
+      expect(result[0]?.assign_scores_to).toEqual([{ name: "Test Profile" }]);
+    });
+
+    test("should include CFs from default groups with default=true", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Default Group 1",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [
+          { name: "cf1", trash_id: "cf1", required: false, default: true },
+          { name: "cf2", trash_id: "cf2", required: false, default: false },
+        ],
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.trash_ids).toEqual(["cf1"]);
+      expect(result[0]?.assign_scores_to).toEqual([{ name: "Test Profile" }]);
+    });
+
+    test("should include CFs with both required=true and default=true", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Default Group 1",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [
+          { name: "cf1", trash_id: "cf1", required: true },
+          { name: "cf2", trash_id: "cf2", required: false, default: true },
+          { name: "cf3", trash_id: "cf3", required: false, default: false },
+        ],
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.trash_ids).toEqual(["cf1", "cf2"]);
+      expect(result[0]?.assign_scores_to).toEqual([{ name: "Test Profile" }]);
+    });
+
+    test("should skip groups without default=true", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Non-default Group",
+        trash_id: "group1",
+        default: "false",
+        custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+      });
+      mapping.set("group2", {
+        name: "No Default Group",
+        trash_id: "group2",
+        custom_formats: [{ name: "cf2", trash_id: "cf2", required: true }],
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(0);
+    });
+
+    test("should respect exclude field for profile", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Excluded Group",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+        quality_profiles: {
+          exclude: {
+            "Test Profile": "profile123",
+          },
+        },
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(0);
+    });
+
+    test("should include from non-excluded profiles only", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Partially Excluded Group",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+        quality_profiles: {
+          exclude: {
+            "Other Profile": "other123",
+          },
+        },
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.trash_ids).toEqual(["cf1"]);
+    });
+
+    test("should handle multiple default groups", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Default Group 1",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+      });
+      mapping.set("group2", {
+        name: "Default Group 2",
+        trash_id: "group2",
+        default: "true",
+        custom_formats: [{ name: "cf2", trash_id: "cf2", required: true }],
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.trash_ids).toEqual(["cf1"]);
+      expect(result[1]?.trash_ids).toEqual(["cf2"]);
+      expect(result[0]?.assign_scores_to).toEqual([{ name: "Test Profile" }]);
+      expect(result[1]?.assign_scores_to).toEqual([{ name: "Test Profile" }]);
+    });
+
+    test("should return empty array when no CFs match criteria", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Default Group with no matching CFs",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [{ name: "cf1", trash_id: "cf1", required: false, default: false }],
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(0);
+    });
+
+    test("should handle empty mapping", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping);
+
+      expect(result).toHaveLength(0);
+    });
   });
 });

--- a/src/types/trashguide.types.ts
+++ b/src/types/trashguide.types.ts
@@ -119,15 +119,31 @@ export type TrashCache = {
 type TrashCFGItem = {
   name: string;
   trash_id: string;
+  /**
+   * Required CFs for the profile. Will be added
+   */
   required: boolean;
+  /**
+   * Selection if should be added even if required is false
+   */
+  default?: boolean;
 };
 
 export type TrashCustomFormatGroups = {
   name: string;
   trash_id: string;
+  trash_description?: string;
+  /**
+   * If this group should be added in always for TRaSH-Guide profiles
+   * Should also be an boolean in theory but is an string in the guide
+   */
+  default?: string;
   custom_formats: TrashCFGItem[];
   quality_profiles?: {
-    exclude: Record<string, string>;
+    /**
+     * Exclude profiles for which this group should not be applied if enabled in default.
+     */
+    exclude: Record<string, string>; // name to id like: "HD Bluray + WEB": "d1d67249d3890e49bc12e275d989a7e9"
   };
 };
 


### PR DESCRIPTION
… profiles automatically

* This will required and defaults CFs defined in the groups always for the TRaSH-Guide profiles
* now all cf-groups will be loaded for TRaSH-Guide templates/profiles
* the CFs in the profiles will be mostly moved from the profiles into groupes where the profiles are referenced
* see https://github.com/TRaSH-Guides/Guides/pull/2455#discussion_r2297832409
* see https://discord.com/channels/492590071455940612/1409911784386596894
* Closes #302 

## Summary by Sourcery

Support automatic inclusion of relevant CF-Groups in TRaSH-Guide profiles by filtering on default/required flags, respecting profile exclusions, integrating the new logic into the template importer, and updating types, tests, and documentation accordingly

New Features:
- Automatically include custom formats from CF-Groups for TRaSH-Guide profiles via a new transformTrashQPCFGroups function
- Integrate CF-Group inclusion into the template import process to load default CF-Groups and assign scores to profiles
- Extend configuration types to capture default flags and optional descriptions for CF-Groups

Documentation:
- Update configuration documentation to explain automatic CF-Group inclusion and link relevant TRaSH-Guides resources

Tests:
- Add unit tests for transformTrashQPCFGroups covering default flags, required flags, profile exclusions, multiple groups, and edge cases