### PR TITLE
feat: implement score for custom format groups closes #196

### DIFF
--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -387,6 +387,8 @@ sonarr:
             #include_unrequired: true # if you want to load all set this to true
         assign_scores_to:
           - name: MyProfile
+            # (experimental) since v1.16.0
+            #score: 0 # optional score to assign to all custom formats in this group. You can still override custom format scores via custom_formats
 ```
 
 Notes:

--- a/examples/full/config/config.yml
+++ b/examples/full/config/config.yml
@@ -75,6 +75,7 @@ sonarr:
             #include_unrequired: true # if you want to load all set this to true
         assign_scores_to:
           - name: ExampleProfile
+            # score: 0 # (experimental) since v1.16.0. Uncomment this line to change score
 
     # Ability to rename profiles
     # renameQualityProfiles:

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -134,6 +134,32 @@ describe("TrashGuide", async () => {
     expect(result).toHaveLength(0);
   });
 
+  test("transformTrashCFGroups - include score when specified", async ({}) => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: true },
+        { name: "cf2", trash_id: "cf2", required: false },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1" }],
+        assign_scores_to: [{ name: "qp1", score: 0 }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.trash_ids!).toHaveLength(1);
+    expect(result[0]!.trash_ids![0]).toBe("cf1");
+    expect(result[0]!.assign_scores_to[0]?.name).toBe("qp1");
+    expect(result[0]!.assign_scores_to[0]?.score).toBe(0);
+  });
+
   describe("transformTrashQPCFGroups", () => {
     const mockTrashQP: TrashQP = {
       trash_id: "profile123",

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -380,7 +380,10 @@ export const transformTrashCFGroups = (trashCFGroupMapping: TrashCFGroupMapping,
       } else {
         const groupCfs = mapping.custom_formats.filter((e) => e.required || include_unrequired === true).map((e) => e.trash_id);
 
-        const customFormatEntry = { trash_ids: groupCfs, assign_scores_to: c.assign_scores_to?.map((v) => ({ name: v.name })) || [] };
+        const customFormatEntry = {
+          trash_ids: groupCfs,
+          assign_scores_to: c.assign_scores_to?.map((v) => ({ name: v.name, score: v.score })) || [],
+        };
 
         if (customFormatEntry.assign_scores_to.length <= 0) {
           logger.warn(`TRaSH CustomFormatGroup mapping ${trashId} would not be applied to any profile. Ignoring.`);

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -41,7 +41,7 @@ export type InputConfigCustomFormat = {
 
 export type InputConfigCustomFormatGroup = {
   trash_guide?: { id: string; include_unrequired?: boolean }[];
-  assign_scores_to?: { name: string }[];
+  assign_scores_to?: { name: string; score?: number }[];
 };
 
 export type InputConfigArrInstance = {


### PR DESCRIPTION
## Summary by Sourcery

Add support for assigning optional scores to custom format groups in TRaSH guide mappings

New Features:
- Allow specifying an optional `score` field when assigning custom format groups to profiles

Enhancements:
- transformTrashCFGroups now includes the `score` value when mapping assign_scores_to entries

Documentation:
- Update configuration documentation and example YAML to document the experimental `score` option

Tests:
- Add unit test for transformTrashCFGroups to verify score handling