### PR TITLE
feat: add possibity to add custom formats without assign to profile

### DIFF
--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -351,6 +351,9 @@ customFormatDefinitions:
     <CodeBlock language="yml" title="CustomFormats with unmanaged QualityProfiles">{ExampleUnamanagedCustomFormats}</CodeBlock>
   </details>
 
+- <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.16.0</span> CustomFormats and CustomFormatGroups do not have to be assigned to a quality profile.
+  If not assigned to a profile they will still be created on the \*arr instance.
+
 ## Cleanup / Deleting CustomFormats {#cleanup-custom-formats}
 
 You can now enable the option to delete all custom formats which are not managed and used in the quality profiles.

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,6 @@ import {
   InputConfigSchema,
   MediaNamingType,
   MergedConfigInstance,
-  InputConfigDelayProfile,
   InputConfigCustomFormat,
 } from "./types/config.types";
 import { TrashCFGroupMapping, TrashQP } from "./types/trashguide.types";
@@ -135,9 +134,7 @@ export const transformConfig = (input: InputConfigSchema): ConfigSchema => {
           const mapped_assign_scores = quality_profiles ?? assign_scores_to;
 
           if (!mapped_assign_scores) {
-            throw new Error(
-              `Mapping failed for profile ${key} -> custom format mapping (assign_scores_to or quality_profiles is missing. Use assign_scores_to)`,
-            );
+            logger.debug(`No assign_scores_to or quality_profiles defined for CF entry '${cf.trash_ids}' in instance '${key}'`);
           }
 
           return { ...rest, assign_scores_to: mapped_assign_scores };

--- a/src/quality-profiles.ts
+++ b/src/quality-profiles.ts
@@ -22,7 +22,7 @@ export const mapQualityProfiles = ({ carrIdMapping }: CFProcessing, { custom_for
   const defaultScoringMap = new Map(quality_profiles.map((obj) => [obj.name, obj]));
 
   for (const { trash_ids, assign_scores_to } of custom_formats) {
-    if (!trash_ids) {
+    if (!trash_ids || !assign_scores_to) {
       continue;
     }
 

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -82,7 +82,9 @@ describe("TrashGuide", async () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.trash_ids!).toHaveLength(1);
     expect(result[0]!.trash_ids![0]).toBe("cf1");
-    expect(result[0]!.assign_scores_to[0]?.name).toBe("qp1");
+    expect(result[0]!.assign_scores_to).toBeDefined();
+    expect(result[0]!.assign_scores_to!).toHaveLength(1);
+    expect(result[0]!.assign_scores_to![0]?.name).toBe("qp1");
   });
 
   test("transformTrashCFGroups - include all if attribute set", async ({}) => {
@@ -107,8 +109,9 @@ describe("TrashGuide", async () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]!.trash_ids!).toHaveLength(2);
+    expect(result[0]!.assign_scores_to).toBeDefined();
     expect(result[0]!.assign_scores_to!).toHaveLength(1);
-    expect(result[0]!.assign_scores_to[0]?.name).toBe("qp1");
+    expect(result[0]!.assign_scores_to![0]?.name).toBe("qp1");
   });
 
   test("transformTrashCFGroups - ignore if mapping missing", async ({}) => {
@@ -156,8 +159,9 @@ describe("TrashGuide", async () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.trash_ids!).toHaveLength(1);
     expect(result[0]!.trash_ids![0]).toBe("cf1");
-    expect(result[0]!.assign_scores_to[0]?.name).toBe("qp1");
-    expect(result[0]!.assign_scores_to[0]?.score).toBe(0);
+    expect(result[0]!.assign_scores_to).toBeDefined();
+    expect(result[0]!.assign_scores_to![0]?.name).toBe("qp1");
+    expect(result[0]!.assign_scores_to![0]?.score).toBe(0);
   });
 
   describe("transformTrashQPCFGroups", () => {

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -385,11 +385,7 @@ export const transformTrashCFGroups = (trashCFGroupMapping: TrashCFGroupMapping,
           assign_scores_to: c.assign_scores_to?.map((v) => ({ name: v.name, score: v.score })) || [],
         };
 
-        if (customFormatEntry.assign_scores_to.length <= 0) {
-          logger.warn(`TRaSH CustomFormatGroup mapping ${trashId} would not be applied to any profile. Ignoring.`);
-        } else {
-          p.push(customFormatEntry);
-        }
+        p.push(customFormatEntry);
       }
     });
     return p;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -178,7 +178,7 @@ export type InputConfigIncludeItem = {
 
 export type ConfigSchema = InputConfigSchema;
 
-export type ConfigCustomFormat = Pick<InputConfigCustomFormat, "trash_ids"> & Required<Pick<InputConfigCustomFormat, "assign_scores_to">>;
+export type ConfigCustomFormat = Pick<InputConfigCustomFormat, "trash_ids"> & Pick<InputConfigCustomFormat, "assign_scores_to">;
 
 export type ConfigCustomFormatList = Pick<ConfigArrInstance, "custom_formats">;
 


### PR DESCRIPTION
* fixes #279

## Summary by Sourcery

Enable creation of custom formats and groups without requiring assignment to a quality profile by relaxing type requirements, adjusting processing logic, and updating documentation

New Features:
- Allow defining custom formats and format groups without assigning them to any quality profile

Enhancements:
- Always include custom format entries in transformTrashCFGroups regardless of assignment
- Replace error on missing assign_scores_to in transformConfig with a debug log
- Relax ConfigCustomFormat TypeScript type to make assign_scores_to optional

Documentation:
- Document that custom formats and groups no longer require profile assignment as of version 1.16.0