### PR TITLE
fix: binary variables

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -92,12 +92,12 @@ jobs:
           bun build src/index.ts \
             --compile --minify --sourcemap src/index.ts \
             --outfile configarr \
-            --define CONFIGARR_VERSION=\"${{ steps.vars.outputs.version }}\" \
-            --define BUILD_TIME=\"${{ steps.vars.outputs.build_time }}\" \
-            --define GITHUB_RUN_ID=\"${{ steps.vars.outputs.run_id }}\" \
-            --define GITHUB_REPO=\"${{ steps.vars.outputs.repo }}\" \
-            --define GITHUB_SHA=\"${{ steps.vars.outputs.sha }}\" \
-            --define BUILD_PLATFORM=\"${{ matrix.platform }}\" \
+            --define 'process.env.CONFIGARR_VERSION="${{ steps.vars.outputs.version }}"' \
+            --define 'process.env.BUILD_TIME="${{ steps.vars.outputs.build_time }}"' \
+            --define 'process.env.GITHUB_RUN_ID="${{ steps.vars.outputs.run_id }}"' \
+            --define 'process.env.GITHUB_REPO="${{ steps.vars.outputs.repo }}"' \
+            --define 'process.env.GITHUB_SHA="${{ steps.vars.outputs.sha }}"' \
+            --define 'process.env.BUILD_PLATFORM="${{ matrix.platform }}"' \
             --bytecode \
             --target=${{ matrix.target }} \
             $WINDOWS_FLAGS \

--- a/docs/docs/installation/binary.md
+++ b/docs/docs/installation/binary.md
@@ -25,3 +25,9 @@ The files are probably compressed and need to be extracted.
 Afterwards you can run the executable as any other program or tool.
 
 Need more help? [open an issue](https://github.com/raydak-labs/configarr/issues).
+
+## FAQ
+
+- `On MacOS if I download files the file is corrupt`: If downloaded via browser or something the resulting executable can be quarantined.
+  - To check attributes: `xattr ./configarr -l`
+  - To remove quarantine: `xattr -dr com.apple.quarantine ./configarr`

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,16 +5,15 @@ const DEFAULT_ROOT_PATH = path.resolve(process.cwd());
 
 // Build-time constants (defined by Bun at compile time)
 // These will be replaced at build time with actual values
-const BUILD_CONFIGARR_VERSION = "dev"; // Will be replaced by --define
-const BUILD_TIME = ""; // Will be replaced by --define
-const GITHUB_RUN_ID = ""; // Will be replaced by --define
-const GITHUB_REPO = ""; // Will be replaced by --define
-const GITHUB_SHA = ""; // Will be replaced by --define
-const BUILD_PLATFORM = ""; // Will be replaced by --define
+const CONFIGARR_VERSION = process.env.CONFIGARR_VERSION ?? "dev"; // Will be replaced by --define
+const BUILD_TIME = process.env.BUILD_TIME ?? ""; // Will be replaced by --define
+const GITHUB_RUN_ID = process.env.GITHUB_RUN_ID ?? ""; // Will be replaced by --define
+const GITHUB_REPO = process.env.GITHUB_REPO ?? ""; // Will be replaced by --define
+const GITHUB_SHA = process.env.GITHUB_SHA ?? ""; // Will be replaced by --define
 
 const schema = z.object({
   // NODE_ENV: z.enum(["production", "development", "test"] as const),
-  CONFIGARR_VERSION: z.string().optional().default(BUILD_CONFIGARR_VERSION),
+  CONFIGARR_VERSION: z.string().optional().default(CONFIGARR_VERSION),
   LOG_LEVEL: z
     .enum(["trace", "debug", "info", "warn", "error", "fatal"] as const)
     .optional()
@@ -100,10 +99,9 @@ export const getHelpers = () => ({
 });
 
 export const getBuildInfo = () => ({
-  version: BUILD_CONFIGARR_VERSION,
+  version: getEnvs().CONFIGARR_VERSION,
   buildTime: BUILD_TIME,
   githubRunId: GITHUB_RUN_ID,
   githubRepo: GITHUB_REPO,
   githubSha: GITHUB_SHA,
-  buildPlatform: BUILD_PLATFORM,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,7 +341,7 @@ const run = async () => {
   logger.info(`Configarr Version: ${getEnvs().CONFIGARR_VERSION}`);
 
   const buildInfo = getBuildInfo();
-  logger.debug(`Build Info: ${buildInfo.buildPlatform} | ${buildInfo.buildTime} | ${buildInfo.githubSha.slice(0, 7)}`);
+  logger.debug(`Build Info: ${buildInfo.buildTime} | ${buildInfo.githubSha.slice(0, 7)} | (run id) ${buildInfo.githubRunId}`);
 
   if (getEnvs().DRY_RUN) {
     logger.info("DryRun: Running in dry-run mode!");


### PR DESCRIPTION
## Summary by Sourcery

Use environment variables for build-time metadata instead of compile-time constants and adjust build workflow accordingly, while adding MacOS binary quarantine FAQ

Enhancements:
- Load build-time metadata from process.env with fallbacks instead of static constants
- Use CONFIGARR_VERSION from environment with a "dev" default and remove BUILD_PLATFORM from build info
- Update GitHub Actions Bun build flags to define process.env.* variables
- Remove buildPlatform property from getBuildInfo

Documentation:
- Add FAQ on handling macOS binary quarantine with xattr commands