### PR TITLE
syncMetadataProfiles only when arrType is lidarr or readarr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,9 @@ const pipeline = async (globalConfig: InputConfigSchema, instanceConfig: InputCo
   }
 
   // Handle metadata profiles (Lidarr / Readarr) - unified sync with optional deletion
-  await syncMetadataProfiles(arrType, config, serverCache);
+  if ("LIDARR" === arrType || "READARR" === arrType) {
+    await syncMetadataProfiles(arrType, config, serverCache);
+  }
 
   await syncRootFolders(arrType, config.root_folders, serverCache);
 


### PR DESCRIPTION
Fixes https://github.com/raydak-labs/configarr/issues/348

## Summary by Sourcery

Bug Fixes:
- Prevent errors by skipping metadata profile sync for arr types that do not support metadata profiles.