### PR TITLE
feat: add media_naming support for Lidarr

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -863,6 +863,19 @@ const mapConfigMediaNamingToApi = async (arrType: ArrType, mediaNaming: MediaNam
     return apiObject;
   }
 
+  if (arrType === "LIDARR") {
+    const apiObject = {
+      ...(mediaNaming.renameTracks != null && { renameTracks: mediaNaming.renameTracks }),
+      ...(mediaNaming.replaceIllegalCharacters != null && { replaceIllegalCharacters: mediaNaming.replaceIllegalCharacters }),
+      ...(mediaNaming.standardTrackFormat && { standardTrackFormat: mediaNaming.standardTrackFormat }),
+      ...(mediaNaming.multiDiscTrackFormat && { multiDiscTrackFormat: mediaNaming.multiDiscTrackFormat }),
+      ...(mediaNaming.artistFolderFormat && { artistFolderFormat: mediaNaming.artistFolderFormat }),
+    };
+
+    logger.debug(apiObject, `Mapped mediaNaming to API:`);
+    return apiObject;
+  }
+
   logger.warn(`MediaNaming not supported for ${arrType}`);
 };
 

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -187,6 +187,13 @@ export type MediaNamingType = {
     daily?: string;
     anime?: string;
   };
+
+  // lidarr
+  renameTracks?: boolean;
+  replaceIllegalCharacters?: boolean;
+  standardTrackFormat?: string;
+  multiDiscTrackFormat?: string;
+  artistFolderFormat?: string;
 };
 
 export type InputConfigQualityProfile = {


### PR DESCRIPTION
Pass through Lidarr-specific naming fields directly to API without TRaSH-Guide mapping since Lidarr doesn't have TRaSH naming templates.

Adds support for:
- renameTracks
- replaceIllegalCharacters
- standardTrackFormat
- multiDiscTrackFormat
- artistFolderFormat

Tested with

```
      media_naming:
        renameTracks: true
        replaceIllegalCharacters: true
        standardTrackFormat: "{Album Title} {(Album Disambiguation)}/{Artist Name}_{Album Title}_{track:00}_{Track Title}"
        multiDiscTrackFormat: "{Album Title} {(Album Disambiguation)}/{Artist Name}_{Album Title}_{medium:00}-{track:00}_{Track Title}"
        artistFolderFormat: "{Artist Name}"
```

## Summary by Sourcery

Add support for passing Lidarr-specific media naming options directly through to the API when configuring media naming.

New Features:
- Support configuring Lidarr media naming options including renameTracks, replaceIllegalCharacters, standardTrackFormat, multiDiscTrackFormat, and artistFolderFormat in the config.

Enhancements:
- Extend media naming configuration mapping to handle Lidarr separately instead of treating it as unsupported.