### PR TITLE
fix: correctly handle metadata sync for unrelated services

### DIFF
--- a/src/metadataProfiles/metadataProfileSyncer.ts
+++ b/src/metadataProfiles/metadataProfileSyncer.ts
@@ -1,4 +1,5 @@
 import { ServerCache } from "../cache";
+import { logger } from "../logger";
 import { ArrType } from "../types/common.types";
 import { MergedConfigInstance } from "../types/config.types";
 import { MetadataProfileSyncResult } from "./metadataProfile.types";
@@ -6,14 +7,15 @@ import { BaseMetadataProfileSync } from "./metadataProfileBase";
 import { LidarrMetadataProfileSync } from "./metadataProfileLidarr";
 import { ReadarrMetadataProfileSync } from "./metadataProfileReadarr";
 
-function createMetadataProfileSync(arrType: ArrType): BaseMetadataProfileSync {
+function createMetadataProfileSync(arrType: ArrType): BaseMetadataProfileSync | null {
   switch (arrType) {
     case "LIDARR":
       return new LidarrMetadataProfileSync();
     case "READARR":
       return new ReadarrMetadataProfileSync();
     default:
-      throw new Error(`Metadata profile synchronization is not supported for Arr type: ${arrType}`);
+      logger.debug(`Metadata profile synchronization is not supported for Arr type: ${arrType}`);
+      return null;
   }
 }
 
@@ -21,11 +23,12 @@ function createMetadataProfileSync(arrType: ArrType): BaseMetadataProfileSync {
  * Sync metadata profiles - handles add/update and deletion in one unified call
  * Takes the full config object to handle all scenarios
  */
-export async function syncMetadataProfiles(
-  arrType: ArrType,
-  config: MergedConfigInstance,
-  serverCache: ServerCache,
-): Promise<MetadataProfileSyncResult> {
+export async function syncMetadataProfiles(arrType: ArrType, config: MergedConfigInstance, serverCache: ServerCache): Promise<void> {
   const sync = createMetadataProfileSync(arrType);
-  return sync.syncMetadataProfiles(config, serverCache);
+
+  if (sync == null) {
+    return;
+  }
+
+  await sync.syncMetadataProfiles(config, serverCache);
 }


### PR DESCRIPTION
Fixes #348 

Closes #349 (@venkyr77 I trying to refactor stuff to be more strictly separated by arr type and try to reduce checks for arr type to only necessary places in order to make the code cleaner and better extensible in the future)

## Summary by Sourcery

Handle metadata profile sync more gracefully for unsupported Arr types.

Bug Fixes:
- Prevent metadata profile synchronization from throwing errors for unsupported Arr types by returning early when no sync implementation exists.

Enhancements:
- Log a debug message instead of throwing for unsupported Arr types and adjust syncMetadataProfiles to be a no-op in that case.