### PR TITLE
fix: changing remote repos should work without manual intervention

### DIFF
--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -92,6 +92,48 @@ sonarr:
 - When loading TRaSH-Guides templates from URLs, specify `source: TRASH` in the include entry
 - Network requests have a 30-second timeout
 
+### Repository URL Configuration
+
+You can override the default repository URLs for TRaSH-Guides and Recyclarr templates:
+
+```yaml title="config.yml"
+# Use a custom TRaSH-Guides fork
+trashGuideUrl: https://github.com/your-org/fork-TRASH-Guides
+
+# Use a custom Recyclarr templates fork
+recyclarrConfigUrl: https://github.com/your-org/fork-recyclarr-configs
+
+# Optional: Specify a custom branch/revision (defaults to 'master')
+trashRevision: main
+recyclarrRevision: develop
+```
+
+**Repository URL Changes:**
+
+When you change `trashGuideUrl` or `recyclarrConfigUrl` in your config:
+
+- Configarr automatically detects existing cached repositories
+- If the remote URL has changed, it deletes the old repository and re-clones from the new URL
+- The new repository is cloned fresh, avoiding any divergent branch issues
+- If the revision doesn't exist in the new repository, a clear error message is provided
+- **No manual cache deletion is required** - changes take effect on the next run
+
+**Example Scenario:**
+
+1. Start with default TRaSH-Guides repository
+2. Change `trashGuideUrl` to a custom fork in your config
+3. Run Configarr - it automatically detects the URL change, deletes the old cache, and clones from the new repository
+4. Done! No manual intervention needed.
+
+**Error Handling:**
+
+If something goes wrong during repository updates:
+
+- Clear error messages are logged explaining what failed
+- The revision may not exist in the new repository
+- The new URL may not be accessible
+- Check the logs for guidance on how to resolve the issue
+
 ## Configuration Files Reference
 
 If you want to deep dive into available values and parameters you can always check the direct source code reference for available configurations: [Source Code](https://github.com/raydak-labs/configarr/blob/main/src/types/config.types.ts)

--- a/src/recyclarr-importer.ts
+++ b/src/recyclarr-importer.ts
@@ -17,7 +17,10 @@ export const cloneRecyclarrTemplateRepo = async () => {
   const revision = applicationConfig.recyclarrRevision ?? "master";
   const sparseDisabled = applicationConfig.enableFullGitClone === true;
 
-  const cloneResult = await cloneGitRepo(rootPath, gitUrl, revision, { disabled: sparseDisabled, sparseDirs: ["radarr/", "sonarr/"] });
+  const cloneResult = await cloneGitRepo(rootPath, gitUrl, revision, {
+    disabled: sparseDisabled,
+    sparseDirs: ["radarr/", "sonarr/"],
+  });
   logger.info(`Recyclarr repo: ref[${cloneResult.ref}], hash[${cloneResult.hash}], path[${cloneResult.localPath}]`);
 };
 

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -78,7 +78,10 @@ export const cloneTrashRepo = async () => {
   const revision = applicationConfig.trashRevision ?? "master";
   const sparseDisabled = applicationConfig.enableFullGitClone === true;
 
-  const cloneResult = await cloneGitRepo(rootPath, gitUrl, revision, { disabled: sparseDisabled, sparseDirs: ["docs/json"] });
+  const cloneResult = await cloneGitRepo(rootPath, gitUrl, revision, {
+    disabled: sparseDisabled,
+    sparseDirs: ["docs/json"],
+  });
   logger.info(`TRaSH-Guides repo: ref[${cloneResult.ref}], hash[${cloneResult.hash}], path[${cloneResult.localPath}]`);
   await createCache();
 };


### PR DESCRIPTION
* fixes #359

## Summary by Sourcery

Handle git cache updates when repository URLs or revisions change and improve error handling and documentation around repository configuration.

Bug Fixes:
- Detect when an existing cached git repository's remote URL differs from the configured URL and automatically delete and re-clone it from the new remote, removing the need for manual cache cleanup.

Enhancements:
- Extract a reusable helper for cloning repositories with optional sparse checkout to reduce duplication and centralize clone behavior.
- Add clearer error handling and logging when checking out revisions or determining remote URLs, including explicit errors when a revision cannot be found.

Documentation:
- Document configuration options for overriding TRaSH-Guides and Recyclarr template repository URLs and revisions, including behavior when URLs change and how errors are reported.