### PR TITLE
Feat(config): Add support for managing UI Config settings

### DIFF
--- a/docs/docs/configuration/_include/config-file-sample.yml
+++ b/docs/docs/configuration/_include/config-file-sample.yml
@@ -111,6 +111,9 @@ sonarr:
     # experimental available in all *arr
     #media_naming_api: {}
 
+    # experimental available in all *arr
+    #ui_config: {}
+
     # naming from recyclarr: https://recyclarr.dev/wiki/yaml/config-reference/media-naming/
     #media_naming: {}
     # (experimental) Manage download clients

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -681,9 +681,9 @@ For more details, check the \*Arr-specific API documentation under the `RemotePa
 
 - Experimental support for `media_management` and `media_naming_api` (since v1.5.0)
   With those you can configure different settings in the different tabs available per *arr.
-  Both fields are under experimental support.
-  The supports elements in those are dependent on the *arr used.
-  Check following API documentation of available fields:
+  These fields are under experimental support.
+  The supported elements are dependent on the *arr used.
+  Check the following API documentation of available fields:
 
   Naming APIs:
   - https://radarr.video/docs/api/#/NamingConfig/get_api_v3_config_naming
@@ -698,3 +698,15 @@ For more details, check the \*Arr-specific API documentation under the `RemotePa
   - https://whisparr.com/docs/api/#/MediaManagementConfig/get_api_v3_config_mediamanagement
   - https://readarr.com/docs/api/#/MediaManagementConfig/get_api_v1_config_mediamanagement
   - https://lidarr.audio/docs/api/#/MediaManagementConfig/get_api_v1_config_mediamanagement
+
+- Experimental support for `ui_config` (since v1.21.0)
+  Allows configuring UI settings like theme, language, calendar preferences, etc.
+  The supported elements are dependent on the \*arr used.
+  Check the following API documentation of available fields:
+
+  UI Config APIs:
+  - https://radarr.video/docs/api/#/UiConfig/put_api_v3_config_ui__id_
+  - https://sonarr.tv/docs/api/#v3/tag/uiconfig/PUT/api/v3/config/ui/{id}
+  - https://whisparr.com/docs/api/#/UiConfig/put_api_v3_config_ui__id_
+  - https://readarr.com/docs/api/#/UiConfig/put_api_v1_config_ui__id_
+  - https://lidarr.audio/docs/api/#/UiConfig/put_api_v1_config_ui__id_

--- a/src/clients/lidarr-client.ts
+++ b/src/clients/lidarr-client.ts
@@ -8,6 +8,7 @@ import {
   QualityDefinitionResource,
   QualityProfileResource,
   RemotePathMappingResource,
+  UiConfigResource,
 } from "../__generated__/lidarr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
@@ -116,6 +117,14 @@ export class LidarrClient implements IArrClient<QualityProfileResource, QualityD
 
   async updateMediamanagement(id: string, data: any) {
     return this.api.v1ConfigMediamanagementUpdate(id, data);
+  }
+
+  async getUiConfig(): Promise<UiConfigResource> {
+    return this.api.v1ConfigUiList();
+  }
+
+  async updateUiConfig(id: string, data: UiConfigResource): Promise<UiConfigResource> {
+    return this.api.v1ConfigUiUpdate(id, data);
   }
 
   async getRootfolders() {

--- a/src/clients/radarr-client.ts
+++ b/src/clients/radarr-client.ts
@@ -7,6 +7,7 @@ import {
   QualityDefinitionResource,
   QualityProfileResource,
   RemotePathMappingResource,
+  UiConfigResource,
 } from "../__generated__/radarr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
@@ -108,6 +109,14 @@ export class RadarrClient implements IArrClient<QualityProfileResource, QualityD
 
   async updateMediamanagement(id: string, data: any) {
     return this.api.v3ConfigMediamanagementUpdate(id, data);
+  }
+
+  async getUiConfig(): Promise<UiConfigResource> {
+    return this.api.v3ConfigUiList();
+  }
+
+  async updateUiConfig(id: string, data: UiConfigResource): Promise<UiConfigResource> {
+    return this.api.v3ConfigUiUpdate(id, data);
   }
 
   async getRootfolders() {

--- a/src/clients/readarr-client.ts
+++ b/src/clients/readarr-client.ts
@@ -8,6 +8,7 @@ import {
   QualityDefinitionResource,
   QualityProfileResource,
   RemotePathMappingResource,
+  UiConfigResource,
 } from "../__generated__/readarr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
@@ -117,6 +118,14 @@ export class ReadarrClient implements IArrClient<
 
   async updateMediamanagement(id: string, data: any) {
     return this.api.v1ConfigMediamanagementUpdate(id, data);
+  }
+
+  async getUiConfig(): Promise<UiConfigResource> {
+    return this.api.v1ConfigUiList();
+  }
+
+  async updateUiConfig(id: string, data: UiConfigResource): Promise<UiConfigResource> {
+    return this.api.v1ConfigUiUpdate(id, data);
   }
 
   async getRootfolders() {

--- a/src/clients/sonarr-client.ts
+++ b/src/clients/sonarr-client.ts
@@ -7,6 +7,7 @@ import {
   QualityDefinitionResource,
   QualityProfileResource,
   RemotePathMappingResource,
+  UiConfigResource,
 } from "../__generated__/sonarr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
@@ -100,6 +101,14 @@ export class SonarrClient implements IArrClient<QualityProfileResource, QualityD
 
   async updateMediamanagement(id: string, data: any) {
     return this.api.v3ConfigMediamanagementUpdate(id, data);
+  }
+
+  async getUiConfig(): Promise<UiConfigResource> {
+    return this.api.v3ConfigUiList();
+  }
+
+  async updateUiConfig(id: string, data: UiConfigResource): Promise<UiConfigResource> {
+    return this.api.v3ConfigUiUpdate(id, data);
   }
 
   async getRootfolders() {

--- a/src/clients/whisparr-client.ts
+++ b/src/clients/whisparr-client.ts
@@ -7,6 +7,7 @@ import {
   QualityDefinitionResource,
   QualityProfileResource,
   RemotePathMappingResource,
+  UiConfigResource,
 } from "../__generated__/whisparr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
@@ -121,6 +122,14 @@ export class WhisparrClient implements IArrClient<
 
   async updateMediamanagement(id: string, data: any) {
     return this.api.v3ConfigMediamanagementUpdate(id, data);
+  }
+
+  async getUiConfig(): Promise<UiConfigResource> {
+    return this.api.v3ConfigUiList();
+  }
+
+  async updateUiConfig(id: string, data: UiConfigResource): Promise<UiConfigResource> {
+    return this.api.v3ConfigUiUpdate(id, data);
   }
 
   async getRootfolders() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { calculateDelayProfilesDiff, deleteAdditionalDelayProfiles, mapToServerD
 import { syncDownloadClients } from "./downloadClients/downloadClientSyncer";
 import { syncDownloadClientConfig } from "./downloadClientConfig/downloadClientConfigSyncer";
 import { syncRemotePaths } from "./remotePaths/remotePathSyncer";
+import { syncUiConfig } from "./uiConfigs/uiConfigSyncer";
 import { logger, logHeading, logInstanceHeading } from "./logger";
 import { calculateMediamanagementDiff, calculateNamingDiff } from "./media-management";
 import { calculateQualityDefinitionDiff, loadQualityDefinitionFromServer } from "./quality-definitions";
@@ -183,6 +184,8 @@ const pipeline = async (globalConfig: InputConfigSchema, instanceConfig: InputCo
       logger.info(`Updated MediaManagement`);
     }
   }
+
+  await syncUiConfig(arrType, config.ui_config);
 
   const serverQP = await loadQualityProfilesFromServer();
   serverCache.qp = serverQP;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -166,6 +166,8 @@ export type InputConfigArrInstance = {
   /* @experimental */
   media_management?: MediaManagementType;
   /* @experimental */
+  ui_config?: UiConfigType;
+  /* @experimental */
   media_naming_api?: MediaNamingApiType;
   renameQualityProfiles?: { from: string; to: string }[];
   cloneQualityProfiles?: { from: string; to: string }[];
@@ -300,6 +302,10 @@ export type InputConfigDownloadClient = {
 };
 
 export type MediaManagementType = {
+  // APIs not consistent across different *arrs. Keeping empty or generic
+};
+
+export type UiConfigType = {
   // APIs not consistent across different *arrs. Keeping empty or generic
 };
 

--- a/src/uiConfigs/uiConfig.types.ts
+++ b/src/uiConfigs/uiConfig.types.ts
@@ -1,0 +1,18 @@
+import { ArrType } from "../types/common.types";
+
+/**
+ * Result of a UI config sync operation
+ */
+export interface UiConfigSyncResult {
+  updated: boolean;
+  arrType: ArrType;
+}
+
+/**
+ * Minimal UI config resource shape with required fields for sync operations.
+ * The actual server response contains many more fields depending on the *arr type.
+ */
+export interface UiConfigResource {
+  id: number;
+  [key: string]: unknown;
+}

--- a/src/uiConfigs/uiConfigSyncer.test.ts
+++ b/src/uiConfigs/uiConfigSyncer.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { syncUiConfig } from "./uiConfigSyncer";
+import { getSpecificClient } from "../clients/unified-client";
+import { getEnvs } from "../env";
+
+// Mock dependencies
+vi.mock("../clients/unified-client", () => ({
+  getSpecificClient: vi.fn(),
+}));
+
+vi.mock("../env", () => ({
+  getEnvs: vi.fn(() => ({ DRY_RUN: false })),
+  getHelpers: vi.fn(() => ({
+    configLocation: "/config/config.yml",
+    secretLocation: "/config/secrets.yml",
+    repoPath: "/repos",
+  })),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("uiConfigSyncer", () => {
+  const mockGetUiConfig = vi.fn();
+  const mockUpdateUiConfig = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSpecificClient).mockReturnValue({
+      getUiConfig: mockGetUiConfig,
+      updateUiConfig: mockUpdateUiConfig,
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("syncUiConfig", () => {
+    test("should skip when uiConfig is undefined", async () => {
+      const result = await syncUiConfig("RADARR", undefined);
+
+      expect(result).toEqual({ updated: false, arrType: "RADARR" });
+      expect(getSpecificClient).not.toHaveBeenCalled();
+      expect(mockGetUiConfig).not.toHaveBeenCalled();
+    });
+
+    test("should handle null config by attempting to sync (null is not undefined)", async () => {
+      // Note: null is different from undefined - the syncer only skips on undefined
+      const serverConfig = { id: 1, theme: "light" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+
+      // null as config will be treated as a valid config object
+      // The diff calculation will compare null against server config
+      const result = await syncUiConfig("SONARR", null as any);
+
+      expect(getSpecificClient).toHaveBeenCalledWith("SONARR");
+      expect(mockGetUiConfig).toHaveBeenCalled();
+    });
+
+    test("should return updated: false when server config is already up-to-date", async () => {
+      const serverConfig = { id: 1, theme: "dark", language: "en" };
+      const localConfig = { theme: "dark", language: "en" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+
+      const result = await syncUiConfig("RADARR", localConfig);
+
+      expect(result).toEqual({ updated: false, arrType: "RADARR" });
+      expect(mockUpdateUiConfig).not.toHaveBeenCalled();
+    });
+
+    test("should detect and apply changes when config differs", async () => {
+      const serverConfig = { id: 1, theme: "light", language: "en" };
+      const localConfig = { theme: "dark" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+      mockUpdateUiConfig.mockResolvedValue({ ...serverConfig, ...localConfig });
+
+      const result = await syncUiConfig("RADARR", localConfig);
+
+      expect(result).toEqual({ updated: true, arrType: "RADARR" });
+      expect(mockUpdateUiConfig).toHaveBeenCalledWith("1", { id: 1, theme: "dark", language: "en" });
+    });
+
+    test("should not update in dry-run mode", async () => {
+      vi.mocked(getEnvs).mockReturnValue({ DRY_RUN: true } as any);
+
+      const serverConfig = { id: 1, theme: "light" };
+      const localConfig = { theme: "dark" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+
+      const result = await syncUiConfig("SONARR", localConfig);
+
+      expect(result).toEqual({ updated: true, arrType: "SONARR" });
+      expect(mockUpdateUiConfig).not.toHaveBeenCalled();
+    });
+
+    test("should throw error when serverConfig.id is missing", async () => {
+      const serverConfig = { theme: "light" }; // No id field
+      const localConfig = { theme: "dark" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+
+      await expect(syncUiConfig("RADARR", localConfig)).rejects.toThrow(
+        "UI config sync failed for RADARR: UI config for RADARR is missing required 'id' field",
+      );
+    });
+
+    test("should throw error when serverConfig.id is null", async () => {
+      const serverConfig = { id: null, theme: "light" };
+      const localConfig = { theme: "dark" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+
+      await expect(syncUiConfig("SONARR", localConfig)).rejects.toThrow("missing required 'id' field");
+    });
+
+    test("should throw error when serverConfig.id is 0 (falsy)", async () => {
+      const serverConfig = { id: 0, theme: "light" };
+      const localConfig = { theme: "dark" };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+
+      await expect(syncUiConfig("LIDARR", localConfig)).rejects.toThrow("missing required 'id' field");
+    });
+
+    test("should propagate client errors with context", async () => {
+      mockGetUiConfig.mockRejectedValue(new Error("Network error"));
+
+      await expect(syncUiConfig("RADARR", { theme: "dark" })).rejects.toThrow("UI config sync failed for RADARR: Network error");
+    });
+
+    test("should handle non-Error thrown objects", async () => {
+      mockGetUiConfig.mockRejectedValue("String error");
+
+      await expect(syncUiConfig("RADARR", { theme: "dark" })).rejects.toThrow("UI config sync failed for RADARR: String error");
+    });
+
+    test("should work with different arr types", async () => {
+      const arrTypes = ["RADARR", "SONARR", "LIDARR", "READARR", "WHISPARR"] as const;
+
+      for (const arrType of arrTypes) {
+        vi.clearAllMocks();
+        const serverConfig = { id: 1, theme: "light" };
+        const localConfig = { theme: "dark" };
+
+        mockGetUiConfig.mockResolvedValue(serverConfig);
+        mockUpdateUiConfig.mockResolvedValue({ ...serverConfig, ...localConfig });
+
+        const result = await syncUiConfig(arrType, localConfig);
+
+        expect(result).toEqual({ updated: true, arrType });
+        expect(getSpecificClient).toHaveBeenCalledWith(arrType);
+      }
+    });
+
+    test("should merge server config with local config on update", async () => {
+      const serverConfig = {
+        id: 1,
+        theme: "light",
+        language: "en",
+        firstDayOfWeek: 0,
+        calendarWeekColumnHeader: "ddd",
+      };
+      const localConfig = {
+        theme: "dark",
+        firstDayOfWeek: 1,
+      };
+
+      mockGetUiConfig.mockResolvedValue(serverConfig);
+      mockUpdateUiConfig.mockResolvedValue({});
+
+      await syncUiConfig("RADARR", localConfig);
+
+      expect(mockUpdateUiConfig).toHaveBeenCalledWith("1", {
+        id: 1,
+        theme: "dark",
+        language: "en",
+        firstDayOfWeek: 1,
+        calendarWeekColumnHeader: "ddd",
+      });
+    });
+  });
+});

--- a/src/uiConfigs/uiConfigSyncer.ts
+++ b/src/uiConfigs/uiConfigSyncer.ts
@@ -1,0 +1,73 @@
+import { getSpecificClient } from "../clients/unified-client";
+import { logger } from "../logger";
+import { ArrType } from "../types/common.types";
+import type { UiConfigType } from "../types/config.types";
+import { UiConfigSyncResult, UiConfigResource } from "./uiConfig.types";
+import { compareObjectsCarr } from "../util";
+import { getEnvs } from "../env";
+
+/**
+ * Type guard to validate that server config has the required id field
+ */
+function hasValidId(config: Record<string, unknown>): config is UiConfigResource {
+  return typeof config.id === "number" && config.id > 0;
+}
+
+/**
+ * Sync UI config for a specific *Arr instance
+ */
+export async function syncUiConfig(arrType: ArrType, uiConfig: UiConfigType | undefined): Promise<UiConfigSyncResult> {
+  // If ui_config is undefined/not present, skip management entirely
+  if (uiConfig === undefined) {
+    logger.debug(`No UI config specified for ${arrType}`);
+    return { updated: false, arrType };
+  }
+
+  try {
+    // Get specific client for this arrType - TypeScript infers the correct type
+    const client = getSpecificClient(arrType);
+
+    // Fetch current server UI config
+    logger.debug(`Fetching UI config from ${arrType}...`);
+    const serverConfig = await client.getUiConfig();
+
+    // Cast to generic record for comparison - generated types don't have index signatures
+    const serverConfigRecord = serverConfig as Record<string, unknown>;
+
+    // Calculate diff directly using compareObjectsCarr
+    const { changes, equal } = compareObjectsCarr(serverConfigRecord, uiConfig);
+
+    if (equal) {
+      logger.info(`UI config for ${arrType} is already up-to-date`);
+      return { updated: false, arrType };
+    }
+
+    logger.info(`UI config changes detected for ${arrType}: ${changes.length} differences`);
+    logger.debug(`UI config changes: ${changes.join(", ")}`);
+
+    // Respect dry-run mode
+    if (getEnvs().DRY_RUN) {
+      logger.info(`DryRun: Would update UI config for ${arrType}`);
+      return { updated: true, arrType };
+    }
+
+    // Validate server config has required id field
+    if (!hasValidId(serverConfigRecord)) {
+      throw new Error(`UI config for ${arrType} is missing required 'id' field`);
+    }
+
+    // Execute update - merge server config with local config
+    const updatedConfig = {
+      ...serverConfig,
+      ...uiConfig,
+    };
+
+    await client.updateUiConfig(serverConfigRecord.id.toString(), updatedConfig);
+    logger.info(`Successfully updated UI config for ${arrType}`);
+    return { updated: true, arrType };
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Failed to sync UI config for ${arrType}: ${errorMessage}`);
+    throw new Error(`UI config sync failed for ${arrType}: ${errorMessage}`);
+  }
+}


### PR DESCRIPTION
Supersedes #374

## Summary by Sourcery

Add experimental support for syncing UI configuration settings across all supported *Arr instances via the config file.

New Features:
- Allow defining experimental `ui_config` settings in the YAML config to manage UI preferences for all supported *Arr instances.
- Expose client methods to read and update UI configuration on Sonarr, Radarr, Lidarr, Readarr, and Whisparr.
- Introduce a UI config sync pipeline that compares local and server UI settings, supports dry-run mode, and updates the remote config when differences are detected.

Enhancements:
- Extend configuration types and comparison utilities to support UI configuration data alongside existing media management options.

Documentation:
- Document experimental `ui_config` support in the configuration reference and sample config, including links to relevant *Arr API endpoints.