### PR TITLE
fix: ignore api key when syncing download clients

### DIFF
--- a/src/downloadClients/downloadClientGeneric.test.ts
+++ b/src/downloadClients/downloadClientGeneric.test.ts
@@ -172,7 +172,7 @@ describe("GenericDownloadClientSync – ARR type handling", () => {
       expect(isEqual).toBe(true);
     });
 
-    test("handles password masking without false diff", () => {
+    test("handles password and apiKey masking without false diff", () => {
       sync = new GenericDownloadClientSync("RADARR");
       const cache = new ServerCache([], [], [], []);
 
@@ -190,6 +190,7 @@ describe("GenericDownloadClientSync – ARR type handling", () => {
           { name: "host", value: "qbittorrent" },
           { name: "port", value: 8080 },
           { name: "password", value: "********" }, // Masked password from server
+          { name: "apiKey", value: "********" }, // Masked api_key from server
         ],
         tags: [],
       };
@@ -203,7 +204,8 @@ describe("GenericDownloadClientSync – ARR type handling", () => {
         fields: {
           host: "qbittorrent",
           port: 8080,
-          password: "changeme", // Actual password in config
+          password: "changeme_p", // Actual password in config
+          api_key: "changeme_k", // Actual api_key in config
         },
       };
 

--- a/src/downloadClients/downloadClientGeneric.ts
+++ b/src/downloadClients/downloadClientGeneric.ts
@@ -58,7 +58,7 @@ export class GenericDownloadClientSync extends BaseDownloadClientSync {
       // Special handling for password fields - server masks them as "********" unless update_password is enabled
       if (
         !valuesMatch &&
-        fieldName.toLowerCase().includes("password") &&
+        (fieldName.toLowerCase().includes("password") || fieldName.toLowerCase().includes("apikey")) &&
         serverValue === "********" &&
         typeof configValue === "string" &&
         configValue.length > 0 &&


### PR DESCRIPTION
SABnzbd uses authorization with an API key. Right now, Configarr overwrites the download client with `akiKey` auth every time.

This PR fixes this behavior.

## Summary by Sourcery

Prevent download client sync from overwriting API key–based authorization when the server returns masked credentials.

Bug Fixes:
- Treat masked API key fields like masked passwords so they no longer trigger unnecessary config updates during download client sync.

Tests:
- Extend generic download client sync tests to cover API key masking alongside password masking.