### PR TITLE
nix: upgrade to v1.24.0 and fix deprecations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1763759067,
-        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764474957,
-        "narHash": "sha256-RCNYRb7zHt+qycQwfTD/Zxnbd4Sxi2fgvkeAljtLEOs=",
+        "lastModified": 1773597492,
+        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "890f57fde071de281cd0e950cd80ea3e1ab55e75",
+        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {

--- a/pkgs/nix/package.nix
+++ b/pkgs/nix/package.nix
@@ -39,14 +39,15 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkgs.makeBinaryWrapper
     pkgs.nodejs_24
-    pkgs.pnpm.configHook
+    pkgs.pnpm
+    pkgs.pnpmConfigHook
   ];
 
   pname = "configarr";
 
-  pnpmDeps = pkgs.pnpm.fetchDeps {
+  pnpmDeps = pkgs.fetchPnpmDeps {
     fetcherVersion = 1;
-    hash = "sha256-0P5gT29uLCmm10Xerk9ZVblEoauTEd9jzi0jseO3Ojc=";
+    hash = "sha256-qH2H7sJ3rMWutPUSpBtBTtIxQqwEUXFCyj+eoygdfjg=";
     inherit (finalAttrs) pname src version;
   };
 
@@ -54,8 +55,8 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "raydak-labs";
     repo = "configarr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-fgv6wiK5wh0jAczJWy3Iqs3OK81ckNr3bOZD32bTCQQ=";
+    hash = "sha256-Kd8EY+qTLv9AQGdLjqW2iU215g/ay9EKcMzTZej9dZk=";
   };
 
-  version = "1.17.2";
+  version = "1.24.0";
 })


### PR DESCRIPTION
## Summary
  - Bump package version from 1.17.2 to 1.24.0 (source hash + pnpm deps hash updated)
  - Replace deprecated `pnpm.configHook` with top-level `pnpmConfigHook`
  - Replace deprecated `pnpm.fetchDeps` with top-level `fetchPnpmDeps`
  - Add `pnpm` to `nativeBuildInputs` (required by the new `pnpmConfigHook` which no longer bundles it)
  - Update flake inputs (`flake-parts`, `nixpkgs`) to latest

  ## Test plan
  - [x] `nix build .#packages.x86_64-linux.default` succeeds with zero deprecation warnings
  - [x] Built binary runs and prints version info
  - [x] `nix flake check` passes clean

## Summary by Sourcery

Upgrade the Nix package definition for configarr to the latest release and align the Nix/pnpm integration with current non-deprecated interfaces.

Bug Fixes:
- Eliminate Nix build deprecation warnings by switching to the new pnpmConfigHook and fetchPnpmDeps interfaces.

Enhancements:
- Update the configarr package to version 1.24.0 with refreshed source and dependency hashes.

Build:
- Adjust Nix derivation to use top-level pnpmConfigHook and fetchPnpmDeps and add pnpm as a native build input.
- Refresh flake inputs (e.g., nixpkgs and flake-parts) in flake.lock to current versions.