### PR TITLE
feat: log warnings for conflicting custom formats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { syncMetadataProfiles } from "./metadataProfiles/metadataProfileSyncer";
 import { cloneRecyclarrTemplateRepo } from "./recyclarr-importer";
 import { loadServerTags } from "./tags";
 import { getTelemetryInstance, Telemetry } from "./telemetry";
-import { cloneTrashRepo, loadQualityDefinitionFromTrash, transformTrashQDs } from "./trash-guide";
+import { checkCustomFormatConflicts, cloneTrashRepo, loadQualityDefinitionFromTrash, transformTrashQDs } from "./trash-guide";
 import { ArrType } from "./types/common.types";
 import { InputConfigArrInstance, InputConfigSchema } from "./types/config.types";
 import { TrashArrSupportedConst, TrashQualityDefinition, TrashQualityDefinitionQuality } from "./types/trashguide.types";
@@ -56,6 +56,8 @@ const pipeline = async (globalConfig: InputConfigSchema, instanceConfig: InputCo
 
   const idsToManage = calculateCFsToManage(config);
   logger.debug(Array.from(idsToManage), `CustomFormats to manage`);
+
+  checkCustomFormatConflicts(arrType, idsToManage);
 
   const mergedCFs = await loadCustomFormatDefinitions(idsToManage, arrType, config.customFormatDefinitions || []);
 

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -1,8 +1,16 @@
 import fs from "node:fs";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { loadAllQDsFromTrash, loadQPFromTrash, transformTrashCFGroups, transformTrashQDs, transformTrashQPCFGroups } from "./trash-guide";
+import {
+  checkCustomFormatConflicts,
+  loadAllQDsFromTrash,
+  loadConflictsFromTrash,
+  loadQPFromTrash,
+  transformTrashCFGroups,
+  transformTrashQDs,
+  transformTrashQPCFGroups,
+} from "./trash-guide";
 import { InputConfigCustomFormatGroup } from "./types/config.types";
-import { TrashCFGroupMapping, TrashQualityDefinition, TrashQP } from "./types/trashguide.types";
+import { TrashCFGroupMapping, TrashConflicts, TrashQualityDefinition, TrashQP } from "./types/trashguide.types";
 import * as util from "./util";
 
 describe("TrashGuide", async () => {
@@ -655,6 +663,61 @@ describe("TrashGuide", async () => {
       const result = transformTrashQPCFGroups(mockTrashQP, mapping, true);
 
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("loadConflictsFromTrash", () => {
+    test("should return empty map for unsupported arrType", async () => {
+      const result = await loadConflictsFromTrash("LIDARR");
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    test("should load conflicts from conflicts.json", async () => {
+      const mockConflicts: TrashConflicts = {
+        custom_formats: [
+          {
+            "9c38ebb7384dada637be8899efa68e6f": { name: "SDR", desc: "" },
+            "25c12f78430a3a23413652cbd1d48d77": { name: "SDR (no WEBDL)", desc: "" },
+          },
+        ],
+      };
+
+      vi.spyOn(util, "loadJsonFile").mockReturnValue(mockConflicts);
+
+      const result = await loadConflictsFromTrash("RADARR");
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(1);
+    });
+
+    test("should return empty map when conflicts.json does not exist", async () => {
+      vi.spyOn(util, "loadJsonFile").mockImplementation(() => {
+        throw new Error("ENOENT: no such file or directory");
+      });
+
+      const result = await loadConflictsFromTrash("SONARR");
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    test("should return empty map when conflicts.json has no custom_formats", async () => {
+      const mockConflicts: TrashConflicts = { custom_formats: [] };
+
+      vi.spyOn(util, "loadJsonFile").mockReturnValue(mockConflicts);
+
+      const result = await loadConflictsFromTrash("SONARR");
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe("checkCustomFormatConflicts", () => {
+    test("should return early for unsupported arrType", () => {
+      expect(() => checkCustomFormatConflicts("LIDARR", new Set(["123"]))).not.toThrow();
     });
   });
 });

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -11,6 +11,8 @@ import {
   TrashCache,
   TrashCF,
   TrashCFGroupMapping,
+  TrashConflicts,
+  TrashConflictsMapping,
   TrashCustomFormatGroups,
   TrashQP,
   TrashQualityDefinition,
@@ -44,6 +46,9 @@ const createCache = async () => {
   const sonarrQDSeries = await loadQualityDefinitionFromTrash("series", "SONARR");
   const sonarrQDAnime = await loadQualityDefinitionFromTrash("anime", "SONARR");
 
+  const radarrConflicts = await loadConflictsFromTrash("RADARR");
+  const sonarrConflicts = await loadConflictsFromTrash("SONARR");
+
   cache = {
     SONARR: {
       qualityProfiles: sonarrQP,
@@ -54,6 +59,7 @@ const createCache = async () => {
         series: sonarrQDSeries,
       },
       naming: sonarrNaming,
+      conflicts: sonarrConflicts,
     },
     RADARR: {
       qualityProfiles: radarrQP,
@@ -63,6 +69,7 @@ const createCache = async () => {
         movie: radarrQDMovie,
       },
       naming: radarrNaming,
+      conflicts: radarrConflicts,
     },
   };
 
@@ -321,6 +328,83 @@ export const loadNamingFromTrashRadarr = async (): Promise<TrashRadarrNaming | n
   logger.debug(`(RADARR) Available TRaSH-Guide file keys: ${Object.keys(firstValue.file)}`);
 
   return firstValue;
+};
+
+export const loadConflictsFromTrash = async (arrType: TrashArrSupported): Promise<TrashConflictsMapping> => {
+  if (arrType !== "RADARR" && arrType !== "SONARR") {
+    logger.debug(`Unsupported arrType: ${arrType}. Skipping TrashConflicts.`);
+
+    return new Map();
+  }
+
+  if (cacheReady) {
+    return cache[arrType].conflicts;
+  }
+
+  const conflictsMapping: TrashConflictsMapping = new Map();
+
+  const conflictsPath = arrType === "RADARR" ? trashRepoPaths.radarrConflicts : trashRepoPaths.sonarrConflicts;
+
+  try {
+    const conflictsFile = loadJsonFile<TrashConflicts>(conflictsPath);
+
+    if (conflictsFile && conflictsFile.custom_formats && conflictsFile.custom_formats.length > 0) {
+      conflictsFile.custom_formats.forEach((conflictGroup, index) => {
+        conflictsMapping.set(index, conflictGroup);
+      });
+
+      logger.debug(`(${arrType}) Loaded ${conflictsMapping.size} conflict groups from TRaSH-Guides`);
+    } else {
+      logger.debug(`(${arrType}) No conflicts defined in TRaSH-Guides`);
+    }
+  } catch (err: any) {
+    logger.debug(`(${arrType}) Failed loading TRaSH-Guides conflicts: ${err?.message ?? err}. Continuing without conflicts.`);
+  }
+
+  return conflictsMapping;
+};
+
+export const checkCustomFormatConflicts = (arrType: TrashArrSupported, cfTrashIds: Set<string>) => {
+  if (arrType !== "RADARR" && arrType !== "SONARR") {
+    return;
+  }
+
+  if (!cacheReady) {
+    logger.debug(`(${arrType}) Cache not ready. Cannot check conflicts.`);
+    return;
+  }
+
+  const conflicts = cache[arrType].conflicts;
+
+  if (conflicts.size === 0) {
+    logger.debug(`(${arrType}) No conflicts defined.`);
+    return;
+  }
+
+  if (cfTrashIds.size < 2) {
+    return;
+  }
+
+  let foundConflicts = false;
+
+  for (const [_, conflictGroup] of conflicts) {
+    const conflictingCfs: string[] = [];
+
+    for (const [trashId, entry] of Object.entries(conflictGroup)) {
+      if (cfTrashIds.has(trashId)) {
+        conflictingCfs.push(entry.name);
+      }
+    }
+
+    if (conflictingCfs.length > 1) {
+      foundConflicts = true;
+      logger.warn(`(${arrType}) Conflicting custom formats found: ${conflictingCfs.join(", ")}`);
+    }
+  }
+
+  if (!foundConflicts) {
+    logger.debug(`(${arrType}) No conflicts detected among selected custom formats.`);
+  }
 };
 
 // TODO merge two methods?

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -4,7 +4,7 @@ import { MergedCustomFormatResource } from "./__generated__/mergedTypes";
 import { getConfig } from "./config";
 import { logger } from "./logger";
 import { interpolateSize } from "./quality-definitions";
-import { CFIDToConfigGroup, ConfigarrCF, QualityDefinitionsRadarr, QualityDefinitionsSonarr } from "./types/common.types";
+import { ArrType, CFIDToConfigGroup, ConfigarrCF, QualityDefinitionsRadarr, QualityDefinitionsSonarr } from "./types/common.types";
 import { ConfigCustomFormat, ConfigQualityProfile, ConfigQualityProfileItem, InputConfigCustomFormatGroup } from "./types/config.types";
 import {
   TrashArrSupported,
@@ -330,7 +330,7 @@ export const loadNamingFromTrashRadarr = async (): Promise<TrashRadarrNaming | n
   return firstValue;
 };
 
-export const loadConflictsFromTrash = async (arrType: TrashArrSupported): Promise<TrashConflictsMapping> => {
+export const loadConflictsFromTrash = async (arrType: ArrType): Promise<TrashConflictsMapping> => {
   if (arrType !== "RADARR" && arrType !== "SONARR") {
     logger.debug(`Unsupported arrType: ${arrType}. Skipping TrashConflicts.`);
 
@@ -364,7 +364,7 @@ export const loadConflictsFromTrash = async (arrType: TrashArrSupported): Promis
   return conflictsMapping;
 };
 
-export const checkCustomFormatConflicts = (arrType: TrashArrSupported, cfTrashIds: Set<string>) => {
+export const checkCustomFormatConflicts = (arrType: ArrType, cfTrashIds: Set<string>) => {
   if (arrType !== "RADARR" && arrType !== "SONARR") {
     return;
   }

--- a/src/types/trashguide.types.ts
+++ b/src/types/trashguide.types.ts
@@ -104,6 +104,7 @@ export type TrashCache = {
       anime: TrashQualityDefinition;
     };
     naming: TrashSonarrNaming | null;
+    conflicts: TrashConflictsMapping;
   };
   RADARR: {
     qualityProfiles: Map<string, TrashQP>;
@@ -113,6 +114,7 @@ export type TrashCache = {
       movie: TrashQualityDefinition;
     };
     naming: TrashRadarrNaming | null;
+    conflicts: TrashConflictsMapping;
   };
 };
 
@@ -154,3 +156,15 @@ export type TrashCustomFormatGroups = {
 };
 
 export type TrashCFGroupMapping = Map<string, TrashCustomFormatGroups>;
+
+// Conflict types for mutually exclusive custom formats
+export type TrashConflictEntry = {
+  name: string;
+  desc?: string;
+};
+
+export type TrashConflicts = {
+  custom_formats: Record<string, TrashConflictEntry>[];
+};
+
+export type TrashConflictsMapping = Map<number, Record<string, TrashConflictEntry>>;

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,11 +30,13 @@ export const trashRepoPaths = {
   sonarrQualitySize: `${trashRepoSonarrRoot}/quality-size`,
   sonarrQP: `${trashRepoSonarrRoot}/quality-profiles`,
   sonarrNaming: `${trashRepoSonarrRoot}/naming`,
+  sonarrConflicts: `${trashRepoSonarrRoot}/conflicts.json`,
   radarrCF: `${trashRepoRadarrRoot}/cf`,
   radarrCFGroups: `${trashRepoRadarrRoot}/cf-groups`,
   radarrQualitySize: `${trashRepoRadarrRoot}/quality-size`,
   radarrQP: `${trashRepoRadarrRoot}/quality-profiles`,
   radarrNaming: `${trashRepoRadarrRoot}/naming`,
+  radarrConflicts: `${trashRepoRadarrRoot}/conflicts.json`,
 };
 
 export const recyclarrRepoPaths = {


### PR DESCRIPTION
Add support for loading and checking conflicts.json from TRaSH Guides to warn users when they select mutually exclusive custom formats.

- Add conflict types (TrashConflictEntry, TrashConflicts, TrashConflictsMapping)
- Update TrashCache to include conflicts for both RADARR and SONARR
- Add loadConflictsFromTrash function to load conflicts.json from TRaSH Guides
- Add checkCustomFormatConflicts function to detect conflicts among selected CFs
- Call conflict checking in pipeline after calculating CFs to manage

Resolves GitHub issue for TRaSH Guides conflicts.json integration

## Summary by Sourcery

Integrate TRaSH Guides custom format conflict data into the cache and pipeline to warn when users select mutually exclusive custom formats.

New Features:
- Load TRaSH Guides conflicts.json for Radarr and Sonarr and cache conflict groups alongside existing TRaSH data.
- Detect and log warnings for conflicting custom formats selected in the pipeline based on TRaSH-defined conflicts.

Enhancements:
- Extend TRaSH cache and type definitions to model custom format conflict groups for both Radarr and Sonarr.