### PR TITLE
refactor(internal): move ky-client + mergedTypes from __generated__

### DIFF
--- a/generate-api.ts
+++ b/generate-api.ts
@@ -65,11 +65,7 @@ const main = async () => {
     },
   });
 
-  unlinkSync(path.resolve(PATH_SONARR_DIR, "..ts"));
-  unlinkSync(path.resolve(PATH_RADARR_DIR, "..ts"));
-  unlinkSync(path.resolve(PATH_WHISPARR_DIR, "..ts"));
-  unlinkSync(path.resolve(PATH_READARR_DIR, "..ts"));
-  unlinkSync(path.resolve(PATH_LIDARR_DIR, "..ts"));
+  unlinkSync(path.resolve(PATH_TO_OUTPUT_DIR, "..ts"));
 };
 
 main();

--- a/generate-api.ts
+++ b/generate-api.ts
@@ -17,7 +17,7 @@ const main = async () => {
     singleHttpClient: true,
     // @ts-ignore little hack to have one single client (we are deleting the weird created file for the http-client)
     fileNames: {
-      httpClient: "../ky-client",
+      httpClient: "../../ky-client",
     },
   });
 
@@ -28,7 +28,7 @@ const main = async () => {
     singleHttpClient: true,
     // @ts-ignore little hack to have one single client (we are deleting the weird created file for the http-client)
     fileNames: {
-      httpClient: "../ky-client",
+      httpClient: "../../ky-client",
     },
   });
 
@@ -39,7 +39,7 @@ const main = async () => {
     singleHttpClient: true,
     // @ts-ignore little hack to have one single client (we are deleting the weird created file for the http-client)
     fileNames: {
-      httpClient: "../ky-client",
+      httpClient: "../../ky-client",
     },
   });
 
@@ -50,7 +50,7 @@ const main = async () => {
     singleHttpClient: true,
     // @ts-ignore little hack to have one single client (we are deleting the weird created file for the http-client)
     fileNames: {
-      httpClient: "../ky-client",
+      httpClient: "../../ky-client",
     },
   });
 
@@ -61,7 +61,7 @@ const main = async () => {
     singleHttpClient: true,
     // @ts-ignore little hack to have one single client (we are deleting the weird created file for the http-client)
     fileNames: {
-      httpClient: "../ky-client",
+      httpClient: "../../ky-client",
     },
   });
 

--- a/src/__generated__/lidarr/Api.ts
+++ b/src/__generated__/lidarr/Api.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 import {
   AlbumResource,
   AlbumResourcePagingResource,

--- a/src/__generated__/lidarr/Content.ts
+++ b/src/__generated__/lidarr/Content.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Content<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/lidarr/Feed.ts
+++ b/src/__generated__/lidarr/Feed.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Feed<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/lidarr/Login.ts
+++ b/src/__generated__/lidarr/Login.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 
 export class Login<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/lidarr/Logout.ts
+++ b/src/__generated__/lidarr/Logout.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Logout<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/lidarr/Path.ts
+++ b/src/__generated__/lidarr/Path.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Path<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/lidarr/Ping.ts
+++ b/src/__generated__/lidarr/Ping.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 import { PingResource } from "./data-contracts";
 
 export class Ping<SecurityDataType = unknown> {

--- a/src/__generated__/radarr/Api.ts
+++ b/src/__generated__/radarr/Api.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 import {
   AlternativeTitleResource,
   ApiInfoResource,

--- a/src/__generated__/radarr/Content.ts
+++ b/src/__generated__/radarr/Content.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Content<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/radarr/Feed.ts
+++ b/src/__generated__/radarr/Feed.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 import { CalendarReleaseType } from "./data-contracts";
 
 export class Feed<SecurityDataType = unknown> {

--- a/src/__generated__/radarr/Login.ts
+++ b/src/__generated__/radarr/Login.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 
 export class Login<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/radarr/Logout.ts
+++ b/src/__generated__/radarr/Logout.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Logout<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/radarr/Path.ts
+++ b/src/__generated__/radarr/Path.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Path<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/radarr/Ping.ts
+++ b/src/__generated__/radarr/Ping.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 import { PingResource } from "./data-contracts";
 
 export class Ping<SecurityDataType = unknown> {

--- a/src/__generated__/readarr/Api.ts
+++ b/src/__generated__/readarr/Api.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 import {
   ApiInfoResource,
   AuthorEditorResource,

--- a/src/__generated__/readarr/Content.ts
+++ b/src/__generated__/readarr/Content.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Content<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/readarr/Feed.ts
+++ b/src/__generated__/readarr/Feed.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Feed<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/readarr/Login.ts
+++ b/src/__generated__/readarr/Login.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 
 export class Login<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/readarr/Logout.ts
+++ b/src/__generated__/readarr/Logout.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Logout<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/readarr/Path.ts
+++ b/src/__generated__/readarr/Path.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Path<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/readarr/Ping.ts
+++ b/src/__generated__/readarr/Ping.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 import { PingResource } from "./data-contracts";
 
 export class Ping<SecurityDataType = unknown> {

--- a/src/__generated__/sonarr/Api.ts
+++ b/src/__generated__/sonarr/Api.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 import {
   AutoTaggingResource,
   BackupResource,

--- a/src/__generated__/sonarr/Content.ts
+++ b/src/__generated__/sonarr/Content.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Content<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/sonarr/Feed.ts
+++ b/src/__generated__/sonarr/Feed.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Feed<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/sonarr/Login.ts
+++ b/src/__generated__/sonarr/Login.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 
 export class Login<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/sonarr/Logout.ts
+++ b/src/__generated__/sonarr/Logout.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Logout<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/sonarr/Path.ts
+++ b/src/__generated__/sonarr/Path.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Path<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/sonarr/Ping.ts
+++ b/src/__generated__/sonarr/Ping.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 import { PingResource } from "./data-contracts";
 
 export class Ping<SecurityDataType = unknown> {

--- a/src/__generated__/whisparr/Api.ts
+++ b/src/__generated__/whisparr/Api.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 import {
   AutoTaggingResource,
   BackupResource,

--- a/src/__generated__/whisparr/Api.ts
+++ b/src/__generated__/whisparr/Api.ts
@@ -54,6 +54,7 @@ import {
   NamingConfigResource,
   NotificationResource,
   ParseResource,
+  QualityDefinitionLimitsResource,
   QualityDefinitionResource,
   QualityProfileResource,
   QueueBulkResource,
@@ -1067,6 +1068,10 @@ export class Api<SecurityDataType = unknown> {
       episodeIds?: number[];
       /** @format int32 */
       episodeFileId?: number;
+      /** @default false */
+      includeSeries?: boolean;
+      /** @default false */
+      includeEpisodeFile?: boolean;
       /** @default false */
       includeImages?: boolean;
     },
@@ -3012,6 +3017,22 @@ export class Api<SecurityDataType = unknown> {
       body: data,
       secure: true,
       type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * No description
+   *
+   * @tags QualityDefinition
+   * @name V3QualitydefinitionLimitsList
+   * @request GET:/api/v3/qualitydefinition/limits
+   * @secure
+   */
+  v3QualitydefinitionLimitsList = (params: RequestParams = {}) =>
+    this.http.request<QualityDefinitionLimitsResource, any>({
+      path: `/api/v3/qualitydefinition/limits`,
+      method: "GET",
+      secure: true,
+      format: "json",
       ...params,
     });
   /**

--- a/src/__generated__/whisparr/Content.ts
+++ b/src/__generated__/whisparr/Content.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Content<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/whisparr/Feed.ts
+++ b/src/__generated__/whisparr/Feed.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Feed<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/whisparr/Login.ts
+++ b/src/__generated__/whisparr/Login.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { ContentType, HttpClient, RequestParams } from "./../ky-client";
+import { ContentType, HttpClient, RequestParams } from "./../../ky-client";
 
 export class Login<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/whisparr/Logout.ts
+++ b/src/__generated__/whisparr/Logout.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Logout<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/whisparr/Path.ts
+++ b/src/__generated__/whisparr/Path.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 
 export class Path<SecurityDataType = unknown> {
   http: HttpClient<SecurityDataType>;

--- a/src/__generated__/whisparr/Ping.ts
+++ b/src/__generated__/whisparr/Ping.ts
@@ -10,7 +10,7 @@
  * ---------------------------------------------------------------
  */
 
-import { HttpClient, RequestParams } from "./../ky-client";
+import { HttpClient, RequestParams } from "./../../ky-client";
 import { PingResource } from "./data-contracts";
 
 export class Ping<SecurityDataType = unknown> {

--- a/src/__generated__/whisparr/data-contracts.ts
+++ b/src/__generated__/whisparr/data-contracts.ts
@@ -549,6 +549,8 @@ export interface EpisodeResource {
   seasonNumber?: number;
   title?: string | null;
   releaseDate?: DateOnly;
+  /** @format date-time */
+  lastSearchTime?: string | null;
   /** @format int32 */
   runtime?: number;
   overview?: string | null;
@@ -1128,6 +1130,13 @@ export interface Quality {
   resolution?: number;
 }
 
+export interface QualityDefinitionLimitsResource {
+  /** @format int32 */
+  min?: number;
+  /** @format int32 */
+  max?: number;
+}
+
 export interface QualityDefinitionResource {
   /** @format int32 */
   id?: number;
@@ -1169,6 +1178,8 @@ export interface QualityProfileResource {
   minFormatScore?: number;
   /** @format int32 */
   cutoffFormatScore?: number;
+  /** @format int32 */
+  minUpgradeFormatScore?: number;
   formatItems?: ProfileFormatItemResource[] | null;
 }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,7 +3,7 @@ import {
   MergedQualityDefinitionResource,
   MergedQualityProfileResource,
   MergedTagResource,
-} from "./__generated__/mergedTypes";
+} from "./types/merged.types";
 import { ArrClientLanguageResource } from "./clients/unified-client";
 import { logger } from "./logger";
 import type { DownloadClientResource } from "./types/download-client.types";

--- a/src/clients/lidarr-client.ts
+++ b/src/clients/lidarr-client.ts
@@ -1,4 +1,4 @@
-import { KyHttpClient } from "../__generated__/ky-client";
+import { KyHttpClient } from "../ky-client";
 import { Api } from "../__generated__/lidarr/Api";
 import {
   CustomFormatResource,

--- a/src/clients/radarr-client.ts
+++ b/src/clients/radarr-client.ts
@@ -1,4 +1,4 @@
-import { KyHttpClient } from "../__generated__/ky-client";
+import { KyHttpClient } from "../ky-client";
 import { Api } from "../__generated__/radarr/Api";
 import {
   CustomFormatResource,

--- a/src/clients/readarr-client.ts
+++ b/src/clients/readarr-client.ts
@@ -1,4 +1,4 @@
-import { KyHttpClient } from "../__generated__/ky-client";
+import { KyHttpClient } from "../ky-client";
 import { Api } from "../__generated__/readarr/Api";
 import {
   CustomFormatResource,

--- a/src/clients/sonarr-client.ts
+++ b/src/clients/sonarr-client.ts
@@ -1,4 +1,4 @@
-import { KyHttpClient } from "../__generated__/ky-client";
+import { KyHttpClient } from "../ky-client";
 import { Api } from "../__generated__/sonarr/Api";
 import {
   CustomFormatResource,

--- a/src/clients/unified-client.ts
+++ b/src/clients/unified-client.ts
@@ -1,4 +1,4 @@
-import { MergedCustomFormatResource, MergedQualityDefinitionResource, MergedQualityProfileResource } from "../__generated__/mergedTypes";
+import { MergedCustomFormatResource, MergedQualityDefinitionResource, MergedQualityProfileResource } from "../types/merged.types";
 import { logger } from "../logger";
 import { ArrType } from "../types/common.types";
 import type { DownloadClientResource } from "../types/download-client.types";

--- a/src/clients/whisparr-client.ts
+++ b/src/clients/whisparr-client.ts
@@ -1,4 +1,4 @@
-import { KyHttpClient } from "../__generated__/ky-client";
+import { KyHttpClient } from "../ky-client";
 import { Api } from "../__generated__/whisparr/Api";
 import {
   CustomFormatResource,

--- a/src/custom-formats.ts
+++ b/src/custom-formats.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { MergedCustomFormatResource } from "./__generated__/mergedTypes";
+import { MergedCustomFormatResource } from "./types/merged.types";
 import { getUnifiedClient } from "./clients/unified-client";
 import { getConfig } from "./config";
 import { getEnvs } from "./env";

--- a/src/delay-profiles.test.ts
+++ b/src/delay-profiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { MergedDelayProfileResource } from "./__generated__/mergedTypes";
+import { MergedDelayProfileResource } from "./types/merged.types";
 
 // Hoist the mock to ensure it runs before imports
 const mockGetDelayProfiles = vi.hoisted(() => vi.fn());

--- a/src/delay-profiles.ts
+++ b/src/delay-profiles.ts
@@ -1,7 +1,7 @@
 import { getUnifiedClient } from "./clients/unified-client";
 import { logger } from "./logger";
 import { InputConfigDelayProfile } from "./types/config.types";
-import { MergedDelayProfileResource, MergedTagResource } from "./__generated__/mergedTypes";
+import { MergedDelayProfileResource, MergedTagResource } from "./types/merged.types";
 
 export const deleteAdditionalDelayProfiles = async () => {
   const api = getUnifiedClient();

--- a/src/downloadClients/downloadClientSyncer.test.ts
+++ b/src/downloadClients/downloadClientSyncer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { MergedTagResource } from "../__generated__/mergedTypes";
+import type { MergedTagResource } from "../types/merged.types";
 import type { DownloadClientResource, TagResource } from "../__generated__/radarr/data-contracts";
 import { DownloadProtocol } from "../__generated__/radarr/data-contracts";
 import { ServerCache } from "../cache";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { getBuildInfo, getEnvs, initEnvs } from "./env";
 initEnvs();
 
 import fs from "node:fs";
-import { MergedCustomFormatResource, MergedQualityProfileResource } from "./__generated__/mergedTypes";
+import { MergedCustomFormatResource, MergedQualityProfileResource } from "./types/merged.types";
 import { ServerCache } from "./cache";
 import { configureApi, getUnifiedClient, unsetApi } from "./clients/unified-client";
 import { getConfig, mergeConfigsAndTemplates } from "./config";

--- a/src/ky-client.test.ts
+++ b/src/ky-client.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import kyDefault, { HTTPError, NormalizedOptions } from "ky";
-import { HttpClient } from "./__generated__/ky-client";
+import { HttpClient } from "./ky-client";
 
 vi.mock("ky", async (importOriginal) => {
   const actual = await importOriginal<typeof import("ky")>();

--- a/src/ky-client.ts
+++ b/src/ky-client.ts
@@ -1,8 +1,8 @@
 // Copied and modified from here: https://github.com/acacode/swagger-typescript-api/pull/690
 import type { BeforeRequestHook, Hooks, KyInstance, Options as KyOptions, NormalizedOptions } from "ky";
 import ky, { HTTPError } from "ky";
-import { logger } from "../logger";
-import { createConnectionErrorParts } from "../clients/unified-client";
+import { logger } from "./logger";
+import { createConnectionErrorParts } from "./clients/unified-client";
 
 function toErrorMessage(value: unknown): string {
   if (value === null) return "null";

--- a/src/quality-definitions.test.ts
+++ b/src/quality-definitions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { MergedQualityDefinitionResource } from "./__generated__/mergedTypes";
+import { MergedQualityDefinitionResource } from "./types/merged.types";
 import { calculateQualityDefinitionDiff, interpolateSize } from "./quality-definitions";
 import { TrashQualityDefinition } from "./types/trashguide.types";
 

--- a/src/quality-definitions.ts
+++ b/src/quality-definitions.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { MergedQualityDefinitionResource } from "./__generated__/mergedTypes";
+import { MergedQualityDefinitionResource } from "./types/merged.types";
 import { getUnifiedClient } from "./clients/unified-client";
 import { getEnvs } from "./env";
 import { logger } from "./logger";

--- a/src/quality-profiles.test.ts
+++ b/src/quality-profiles.test.ts
@@ -7,7 +7,7 @@ import {
   MergedQualityDefinitionResource,
   MergedQualityProfileQualityItemResource,
   MergedQualityProfileResource,
-} from "./__generated__/mergedTypes";
+} from "./types/merged.types";
 import { ServerCache } from "./cache";
 import {
   calculateQualityProfilesDiff,

--- a/src/quality-profiles.ts
+++ b/src/quality-profiles.ts
@@ -5,7 +5,7 @@ import {
   MergedQualityDefinitionResource,
   MergedQualityProfileQualityItemResource,
   MergedQualityProfileResource,
-} from "./__generated__/mergedTypes";
+} from "./types/merged.types";
 import { ServerCache } from "./cache";
 import { ArrClientLanguageResource, getUnifiedClient } from "./clients/unified-client";
 import { getEnvs } from "./env";

--- a/src/rootFolder/rootFolder.types.ts
+++ b/src/rootFolder/rootFolder.types.ts
@@ -1,5 +1,5 @@
 import { InputConfigRootFolder } from "../types/config.types";
-import { MergedRootFolderResource } from "../__generated__/mergedTypes";
+import { MergedRootFolderResource } from "../types/merged.types";
 
 // Shared types for root folder operations
 export interface RootFolderDiff<TConfig extends InputConfigRootFolder = InputConfigRootFolder> {

--- a/src/rootFolder/rootFolderBase.ts
+++ b/src/rootFolder/rootFolderBase.ts
@@ -1,4 +1,4 @@
-import { MergedRootFolderResource } from "../__generated__/mergedTypes";
+import { MergedRootFolderResource } from "../types/merged.types";
 import { ServerCache } from "../cache";
 import { getUnifiedClient, IArrClient } from "../clients/unified-client";
 import { getEnvs } from "../env";

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,7 +1,7 @@
 import { getUnifiedClient } from "./clients/unified-client";
 import { logger } from "./logger";
 import { InputConfigDelayProfile } from "./types/config.types";
-import { MergedDelayProfileResource, MergedTagResource } from "./__generated__/mergedTypes";
+import { MergedDelayProfileResource, MergedTagResource } from "./types/merged.types";
 import { getEnvs } from "./env";
 
 export const loadServerTags = async (): Promise<MergedTagResource[]> => {

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { MergedCustomFormatResource } from "./__generated__/mergedTypes";
+import { MergedCustomFormatResource } from "./types/merged.types";
 import { getConfig } from "./config";
 import { logger } from "./logger";
 import { interpolateSize } from "./quality-definitions";

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -1,4 +1,4 @@
-import { MergedCustomFormatResource, MergedCustomFormatSpecificationSchema } from "../__generated__/mergedTypes";
+import { MergedCustomFormatResource, MergedCustomFormatSpecificationSchema } from "./merged.types";
 import { InputConfigArrInstance } from "./config.types";
 import { TrashCF, TrashCFSpF } from "./trashguide.types";
 

--- a/src/types/merged.types.ts
+++ b/src/types/merged.types.ts
@@ -7,7 +7,7 @@ import {
   QualityProfileResource as RadarrQualityProfileResource,
   RootFolderResource as RadarrRootFolderResource,
   TagResource as RadarrTagResource,
-} from "./radarr/data-contracts";
+} from "../__generated__/radarr/data-contracts";
 import {
   QualityDefinitionResource as QDRSonarr,
   CustomFormatResource as SonarrCustomFormatResource,
@@ -16,7 +16,7 @@ import {
   QualityProfileQualityItemResource as SonarrQualityProfileQualityItemResource,
   QualityProfileResource as SonarrQualityProfileResource,
   RootFolderResource as SonarrRootFolderResource,
-} from "./sonarr/data-contracts";
+} from "../__generated__/sonarr/data-contracts";
 
 // Those types are only to make the API client unified usable.
 // Sonarr and Radarr slightly differ in API fields and therefore at the moment we can ignore those changes.
@@ -58,7 +58,7 @@ export type MergedQualityProfileResource = OmitTyped<QPRMerged, "items"> &
 
 export type MergedCustomFormatSpecificationSchema = RadarrCustomFormatSpecificationSchema & SonarrCustomFormatSpecificationSchema;
 export type MergedRootFolderResource = SonarrRootFolderResource & RadarrRootFolderResource;
-export type MergedDelayProfileResource = import("./sonarr/data-contracts").DelayProfileResource &
-  import("./radarr/data-contracts").DelayProfileResource;
+export type MergedDelayProfileResource = import("../__generated__/sonarr/data-contracts").DelayProfileResource &
+  import("../__generated__/radarr/data-contracts").DelayProfileResource;
 
 export type MergedTagResource = RadarrTagResource;

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { describe, expect, test } from "vitest";
-import { MergedCustomFormatResource } from "./__generated__/mergedTypes";
+import { MergedCustomFormatResource } from "./types/merged.types";
 import { TrashCF, TrashCFSpF } from "./types/trashguide.types";
 import { cloneWithJSON, compareCustomFormats, loadJsonFile, mapImportCfToRequestCf, toCarrCF, zip } from "./util";
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import simpleGit, { CheckRepoActions } from "simple-git";
-import { MergedCustomFormatResource } from "./__generated__/mergedTypes";
+import { MergedCustomFormatResource } from "./types/merged.types";
 import { getHelpers } from "./env";
 import { logger } from "./logger";
 import { ConfigarrCF, ImportCF, UserFriendlyField } from "./types/common.types";


### PR DESCRIPTION
## Summary by Sourcery

Refactor generated client and shared types into stable, non-generated locations and update references across the codebase.

Enhancements:
- Relocate the shared ky HTTP client from the __generated__ directory into the main src tree and point the API generator at the new path.
- Move merged resource types into a dedicated src/types/merged.types module and update all imports to use it.
- Simplify the API generation cleanup step to delete the temporary http client file via a single output directory path.