### PR TITLE
fix: adjust conflicting cf names with different ids

### DIFF
--- a/src/custom-formats.test.ts
+++ b/src/custom-formats.test.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as unifiedClient from "./clients/unified-client";
 import * as config from "./config";
-import { calculateCFsToManage, loadCustomFormatDefinitions, loadLocalCfs, mergeCfSources } from "./custom-formats";
+import * as env from "./env";
+import { calculateCFsToManage, loadCustomFormatDefinitions, loadLocalCfs, manageCf, mergeCfSources } from "./custom-formats";
 import { loadTrashCFs } from "./trash-guide";
-import { CFIDToConfigGroup } from "./types/common.types";
+import { CFIDToConfigGroup, CFProcessing, ConfigarrCF } from "./types/common.types";
 import { ConfigCustomFormatList } from "./types/config.types";
+import { MergedCustomFormatResource } from "./types/merged.types";
 import { TrashCF } from "./types/trashguide.types";
 import * as util from "./util";
+import { logger } from "./logger";
 
 describe("CustomFormats", () => {
   let customCF: TrashCF;
@@ -83,6 +87,64 @@ describe("CustomFormats", () => {
       expect(result.carrIdMapping.has("id1")).toBeTruthy();
       expect(result.carrIdMapping.has("id2")).toBeTruthy();
     });
+
+    it("should keep one cfNameToCarrConfig winner when two trash_ids share the same CF name", () => {
+      const mk = (id: string, name: string, specCount: number) => {
+        const specifications = Array.from({ length: specCount }, (_, i) => ({
+          name: `S${i}`,
+          implementation: "ReleaseGroupSpecification" as const,
+          negate: false,
+          required: false,
+          fields: { value: `^(${i})$` },
+        }));
+        const carrConfig = { configarr_id: id, name, specifications } as unknown as ConfigarrCF;
+        return { carrConfig, requestConfig: util.mapImportCfToRequestCf(carrConfig) };
+      };
+
+      const first = mk("id-a", "Dup", 3);
+      const second = mk("id-b", "Dup", 1);
+      const source: CFIDToConfigGroup = new Map([
+        ["id-a", { carrConfig: first.carrConfig, requestConfig: first.requestConfig }],
+        ["id-b", { carrConfig: second.carrConfig, requestConfig: second.requestConfig }],
+      ]);
+
+      const result = mergeCfSources(new Set(["id-a", "id-b"]), [source, null]);
+
+      expect(result.carrIdMapping.size).toBe(2);
+      expect(result.cfNameToCarrConfig.size).toBe(1);
+      expect(result.cfNameToCarrConfig.get("Dup")?.configarr_id).toBe("id-b");
+      expect(result.cfNameToCarrConfig.get("Dup")?.specifications?.length).toBe(1);
+      const winnerCarr = result.cfNameToCarrConfig.get("Dup")!;
+      const idB = result.carrIdMapping.get("id-b")!;
+      expect(util.compareCustomFormats(util.mapImportCfToRequestCf(winnerCarr), idB.requestConfig).equal).toBe(true);
+    });
+
+    it("should warn when two trash_ids share a name but have different specifications", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      const mk = (id: string, name: string, specCount: number) => {
+        const specifications = Array.from({ length: specCount }, (_, i) => ({
+          name: `S${i}`,
+          implementation: "ReleaseGroupSpecification" as const,
+          negate: false,
+          required: false,
+          fields: { value: `^(${i})$` },
+        }));
+        const carrConfig = { configarr_id: id, name, specifications } as unknown as ConfigarrCF;
+        return { carrConfig, requestConfig: util.mapImportCfToRequestCf(carrConfig) };
+      };
+
+      const first = mk("id-a", "Dup", 2);
+      const second = mk("id-b", "Dup", 1);
+      const source: CFIDToConfigGroup = new Map([
+        ["id-a", { carrConfig: first.carrConfig, requestConfig: first.requestConfig }],
+        ["id-b", { carrConfig: second.carrConfig, requestConfig: second.requestConfig }],
+      ]);
+
+      mergeCfSources(new Set(["id-a", "id-b"]), [source, null]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/trash_id 'id-b' wins over 'id-a'.*Sync uses 'id-b'/));
+      warnSpy.mockRestore();
+    });
   });
 
   describe("calculateCFsToManage", () => {
@@ -148,6 +210,100 @@ describe("CustomFormats", () => {
 
       expect(result.carrIdMapping.size).toBe(1);
       expect(result.carrIdMapping.has("trash1")).toBeTruthy();
+    });
+  });
+
+  describe("manageCf", () => {
+    it("should update each CF name at most once when server already matches desired state", async () => {
+      vi.spyOn(env, "getEnvs").mockReturnValue({
+        DRY_RUN: false,
+      } as ReturnType<typeof env.getEnvs>);
+
+      const specifications = [
+        {
+          name: "S0",
+          implementation: "ReleaseGroupSpecification" as const,
+          negate: false,
+          required: false,
+          fields: { value: "^(0)$" },
+        },
+      ];
+      const carrConfigB = { configarr_id: "id-b", name: "Dup", specifications } as unknown as ConfigarrCF;
+      const requestConfigB = util.mapImportCfToRequestCf(carrConfigB);
+      const carrConfigA = {
+        configarr_id: "id-a",
+        name: "Dup",
+        specifications: [...specifications, { ...specifications[0], name: "S1" }],
+      } as unknown as ConfigarrCF;
+      const requestConfigA = util.mapImportCfToRequestCf(carrConfigA);
+
+      const cfProcessing: CFProcessing = {
+        carrIdMapping: new Map([
+          ["id-a", { carrConfig: carrConfigA, requestConfig: requestConfigA }],
+          ["id-b", { carrConfig: carrConfigB, requestConfig: requestConfigB }],
+        ]),
+        cfNameToCarrConfig: new Map([[carrConfigB.name!, carrConfigB]]),
+      };
+
+      const serverCf: MergedCustomFormatResource = { id: 1, name: "Dup", ...requestConfigB };
+      const serverCfs = new Map<string, MergedCustomFormatResource>([["Dup", serverCf]]);
+
+      const updateCustomFormat = vi.fn();
+      vi.spyOn(unifiedClient, "getUnifiedClient").mockReturnValue({
+        updateCustomFormat,
+        createCustomFormat: vi.fn(),
+      } as unknown as ReturnType<typeof unifiedClient.getUnifiedClient>);
+
+      const out = await manageCf(cfProcessing, serverCfs);
+
+      expect(updateCustomFormat).not.toHaveBeenCalled();
+      expect(out.errorCFs.length).toBe(0);
+    });
+
+    it("should apply a single update per CF name using cfNameToCarrConfig winner when server matches a non-winner trash_id body", async () => {
+      vi.spyOn(env, "getEnvs").mockReturnValue({ DRY_RUN: false } as ReturnType<typeof env.getEnvs>);
+
+      const specifications = [
+        {
+          name: "S0",
+          implementation: "ReleaseGroupSpecification" as const,
+          negate: false,
+          required: false,
+          fields: { value: "^(0)$" },
+        },
+      ];
+      const carrConfigB = { configarr_id: "id-b", name: "Dup", specifications } as unknown as ConfigarrCF;
+      const requestConfigB = util.mapImportCfToRequestCf(carrConfigB);
+      const carrConfigA = {
+        configarr_id: "id-a",
+        name: "Dup",
+        specifications: [...specifications, { ...specifications[0], name: "S1" }],
+      } as unknown as ConfigarrCF;
+      const requestConfigA = util.mapImportCfToRequestCf(carrConfigA);
+
+      const cfProcessing: CFProcessing = {
+        carrIdMapping: new Map([
+          ["id-a", { carrConfig: carrConfigA, requestConfig: requestConfigA }],
+          ["id-b", { carrConfig: carrConfigB, requestConfig: requestConfigB }],
+        ]),
+        cfNameToCarrConfig: new Map([[carrConfigB.name!, carrConfigB]]),
+      };
+
+      const serverCfStale: MergedCustomFormatResource = { id: 1, name: "Dup", ...requestConfigA };
+      const serverCfs = new Map<string, MergedCustomFormatResource>([["Dup", serverCfStale]]);
+
+      const updateCustomFormat = vi.fn().mockResolvedValue({ id: 1, name: "Dup", ...requestConfigB });
+      vi.spyOn(unifiedClient, "getUnifiedClient").mockReturnValue({
+        updateCustomFormat,
+        createCustomFormat: vi.fn(),
+      } as unknown as ReturnType<typeof unifiedClient.getUnifiedClient>);
+
+      await manageCf(cfProcessing, serverCfs);
+
+      expect(updateCustomFormat).toHaveBeenCalledTimes(1);
+      const updatePayload = updateCustomFormat.mock.calls[0]?.[1];
+      expect(updatePayload).toBeDefined();
+      expect(updatePayload).toMatchObject({ ...requestConfigB });
     });
   });
 });

--- a/src/custom-formats.test.ts
+++ b/src/custom-formats.test.ts
@@ -75,6 +75,18 @@ describe("CustomFormats", () => {
   });
 
   describe("mergeCfSources", () => {
+    const mkCfPair = (id: string, name: string, specCount: number) => {
+      const specifications = Array.from({ length: specCount }, (_, i) => ({
+        name: `S${i}`,
+        implementation: "ReleaseGroupSpecification" as const,
+        negate: false,
+        required: false,
+        fields: { value: `^(${i})$` },
+      }));
+      const carrConfig = { configarr_id: id, name, specifications } as unknown as ConfigarrCF;
+      return { carrConfig, requestConfig: util.mapImportCfToRequestCf(carrConfig) };
+    };
+
     it("should merge multiple CF sources correctly", () => {
       const source1: CFIDToConfigGroup = new Map([["id1", { carrConfig: { configarr_id: "id1", name: "CF1" }, requestConfig: {} }]]);
 
@@ -89,20 +101,8 @@ describe("CustomFormats", () => {
     });
 
     it("should keep one cfNameToCarrConfig winner when two trash_ids share the same CF name", () => {
-      const mk = (id: string, name: string, specCount: number) => {
-        const specifications = Array.from({ length: specCount }, (_, i) => ({
-          name: `S${i}`,
-          implementation: "ReleaseGroupSpecification" as const,
-          negate: false,
-          required: false,
-          fields: { value: `^(${i})$` },
-        }));
-        const carrConfig = { configarr_id: id, name, specifications } as unknown as ConfigarrCF;
-        return { carrConfig, requestConfig: util.mapImportCfToRequestCf(carrConfig) };
-      };
-
-      const first = mk("id-a", "Dup", 3);
-      const second = mk("id-b", "Dup", 1);
+      const first = mkCfPair("id-a", "Dup", 3);
+      const second = mkCfPair("id-b", "Dup", 1);
       const source: CFIDToConfigGroup = new Map([
         ["id-a", { carrConfig: first.carrConfig, requestConfig: first.requestConfig }],
         ["id-b", { carrConfig: second.carrConfig, requestConfig: second.requestConfig }],
@@ -121,20 +121,9 @@ describe("CustomFormats", () => {
 
     it("should warn when two trash_ids share a name but have different specifications", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-      const mk = (id: string, name: string, specCount: number) => {
-        const specifications = Array.from({ length: specCount }, (_, i) => ({
-          name: `S${i}`,
-          implementation: "ReleaseGroupSpecification" as const,
-          negate: false,
-          required: false,
-          fields: { value: `^(${i})$` },
-        }));
-        const carrConfig = { configarr_id: id, name, specifications } as unknown as ConfigarrCF;
-        return { carrConfig, requestConfig: util.mapImportCfToRequestCf(carrConfig) };
-      };
 
-      const first = mk("id-a", "Dup", 2);
-      const second = mk("id-b", "Dup", 1);
+      const first = mkCfPair("id-a", "Dup", 2);
+      const second = mkCfPair("id-b", "Dup", 1);
       const source: CFIDToConfigGroup = new Map([
         ["id-a", { carrConfig: first.carrConfig, requestConfig: first.requestConfig }],
         ["id-b", { carrConfig: second.carrConfig, requestConfig: second.requestConfig }],

--- a/src/custom-formats.ts
+++ b/src/custom-formats.ts
@@ -37,12 +37,8 @@ export const loadServerCustomFormats = async (): Promise<MergedCustomFormatResou
   return cfOnServer;
 };
 
-export const manageCf = async (
-  cfProcessing: CFProcessing,
-  serverCfs: Map<string, MergedCustomFormatResource>,
-  cfsToManage: Set<string>,
-) => {
-  const { carrIdMapping: trashIdToObject } = cfProcessing;
+export const manageCf = async (cfProcessing: CFProcessing, serverCfs: Map<string, MergedCustomFormatResource>) => {
+  const { cfNameToCarrConfig } = cfProcessing;
   const api = getUnifiedClient();
 
   let updatedCFs: MergedCustomFormatResource[] = [];
@@ -50,23 +46,16 @@ export const manageCf = async (
   const validCFs: ConfigarrCF[] = [];
   let createCFs: MergedCustomFormatResource[] = [];
 
-  const manageSingle = async (carrId: string) => {
-    const tr = trashIdToObject.get(carrId);
-
-    if (!tr) {
-      logger.warn(`TrashID to manage ${carrId} does not exists`);
-      errorCFs.push(carrId);
-      return;
-    }
-
-    const existingCf = serverCfs.get(tr.carrConfig.name!);
+  const manageSingle = async (cfName: string, carrConfig: ConfigarrCF) => {
+    const requestConfig = mapImportCfToRequestCf(carrConfig);
+    const existingCf = serverCfs.get(cfName);
 
     if (existingCf) {
       // Update if necessary
-      const comparison = compareCustomFormats(existingCf, tr.requestConfig);
+      const comparison = compareCustomFormats(existingCf, requestConfig);
 
       if (!comparison.equal) {
-        logger.debug(`Found mismatch for ${tr.requestConfig.name}: ${comparison.changes}`);
+        logger.debug(`Found mismatch for ${requestConfig.name}: ${comparison.changes}`);
 
         try {
           if (getEnvs().DRY_RUN) {
@@ -75,30 +64,30 @@ export const manageCf = async (
           } else {
             const updatedCf = await api.updateCustomFormat(existingCf.id + "", {
               id: existingCf.id,
-              ...tr.requestConfig,
+              ...requestConfig,
             });
-            logger.debug(`Updated CF ${tr.requestConfig.name}`);
+            logger.debug(`Updated CF ${requestConfig.name}`);
             updatedCFs.push(updatedCf);
           }
         } catch (err: any) {
           const data = err?.response?.data;
           const dataMessage = typeof data === "object" ? (data?.message ?? data?.errorMessage) : data;
           const errorMessage = dataMessage ?? err?.message ?? String(err);
-          logger.error(errorMessage, `Failed updating CF ${tr.requestConfig.name}`);
-          errorCFs.push(tr.carrConfig.configarr_id ?? tr.requestConfig.name ?? "unknown");
-          throw new Error(`Failed updating CF '${tr.requestConfig.name}'. Message: ${errorMessage}`, { cause: err });
+          logger.error(errorMessage, `Failed updating CF ${requestConfig.name}`);
+          errorCFs.push(carrConfig.configarr_id ?? requestConfig.name ?? "unknown");
+          throw new Error(`Failed updating CF '${requestConfig.name}'. Message: ${errorMessage}`, { cause: err });
         }
       } else {
-        validCFs.push(tr.carrConfig);
+        validCFs.push(carrConfig);
       }
     } else {
       // Create
       try {
         if (getEnvs().DRY_RUN) {
-          logger.info(`Would create CF: ${tr.requestConfig.name}`);
+          logger.info(`Would create CF: ${requestConfig.name}`);
         } else {
-          const createResult = await api.createCustomFormat(tr.requestConfig);
-          logger.info(`Created CF ${tr.requestConfig.name}`);
+          const createResult = await api.createCustomFormat(requestConfig);
+          logger.info(`Created CF ${requestConfig.name}`);
           createCFs.push(createResult);
           serverCfs.set(createResult.name!, createResult);
         }
@@ -106,15 +95,15 @@ export const manageCf = async (
         const data = err?.response?.data;
         const dataMessage = typeof data === "object" ? (data?.message ?? data?.errorMessage) : data;
         const errorMessage = dataMessage ?? err?.message ?? String(err);
-        logger.error(errorMessage, `Failed creating CF ${tr.requestConfig.name}`);
-        errorCFs.push(tr.carrConfig.configarr_id ?? tr.requestConfig.name ?? "unknown");
-        throw new Error(`Failed creating CF '${tr.requestConfig.name}'. Message: ${errorMessage}`, { cause: err });
+        logger.error(errorMessage, `Failed creating CF ${requestConfig.name}`);
+        errorCFs.push(carrConfig.configarr_id ?? requestConfig.name ?? "unknown");
+        throw new Error(`Failed creating CF '${requestConfig.name}'. Message: ${errorMessage}`, { cause: err });
       }
     }
   };
 
-  for (const cf of cfsToManage) {
-    await manageSingle(cf);
+  for (const [cfName, carrConfig] of cfNameToCarrConfig) {
+    await manageSingle(cfName, carrConfig);
   }
 
   if (validCFs.length > 0) {
@@ -224,6 +213,8 @@ export const calculateCFsToManage = (yaml: ConfigCustomFormatList) => {
 };
 
 export const mergeCfSources = (idsToManage: Set<string>, listOfCfs: (CFIDToConfigGroup | null)[]): CFProcessing => {
+  const lastTrashIdByCfName = new Map<string, string>();
+
   return listOfCfs.reduce<CFProcessing>(
     (p, c) => {
       if (c == null) {
@@ -240,11 +231,18 @@ export const mergeCfSources = (idsToManage: Set<string>, listOfCfs: (CFIDToConfi
           }
 
           if (p.cfNameToCarrConfig.has(cfName)) {
-            logger.warn(`Overwriting CF with name '${cfName}' (ID: ${test}) during merge.`);
+            const prevCarr = p.cfNameToCarrConfig.get(cfName)!;
+            const prevTid = lastTrashIdByCfName.get(cfName)!;
+            const specsDiffer = !compareCustomFormats(mapImportCfToRequestCf(prevCarr), value.requestConfig).equal;
+            const specNote = specsDiffer ? " Definitions for those ids are not identical;" : "";
+            logger.warn(
+              `Overwriting CF with name '${cfName}': trash_id '${test}' wins over '${prevTid}' (later merge order).${specNote} Sync uses '${test}'.`,
+            );
           }
 
           p.carrIdMapping.set(test, value);
-          p.cfNameToCarrConfig.set(value.carrConfig.name!, value.carrConfig);
+          p.cfNameToCarrConfig.set(cfName, value.carrConfig);
+          lastTrashIdByCfName.set(cfName, test);
         }
       }
 

--- a/src/custom-formats.ts
+++ b/src/custom-formats.ts
@@ -223,9 +223,9 @@ export const mergeCfSources = (idsToManage: Set<string>, listOfCfs: (CFIDToConfi
 
       for (const test of idsToManage) {
         const value = c.get(test);
-        const cfName = value?.carrConfig.name!;
 
         if (value) {
+          const cfName = value.carrConfig.name!;
           if (p.carrIdMapping.has(test)) {
             logger.warn(`Overwriting CF with id '${test}' during merge.`);
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ const pipeline = async (globalConfig: InputConfigSchema, instanceConfig: InputCo
     return p;
   }, new Map<string, MergedCustomFormatResource>());
 
-  const cfUpdateResult = await manageCf(mergedCFs, serverCFMapping, idsToManage);
+  const cfUpdateResult = await manageCf(mergedCFs, serverCFMapping);
 
   // add missing CFs to list because we need it for further steps
   // serverCFs.push(...cfUpdateResult.createCFs);

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -692,21 +692,15 @@ describe("TrashGuide", async () => {
       expect(result).toEqual([]);
     });
 
-    test("should skip conflict groups with less than 2 CFs", async () => {
+    test("should skip conflict groups with fewer than 2 valid trash_ids", async () => {
       const mockConflicts = {
         custom_formats: [
           {
-            trash_id: "group1",
-            name: "Single CF",
-            custom_formats: [{ trash_id: "cf1", name: "CF1" }],
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: { name: "Only one", desc: "" },
           },
           {
-            trash_id: "group2",
-            name: "Valid Group",
-            custom_formats: [
-              { trash_id: "cf2", name: "CF2" },
-              { trash_id: "cf3", name: "CF3" },
-            ],
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: { name: "CF2", desc: "" },
+            cccccccccccccccccccccccccccccccc: { name: "CF3", desc: "" },
           },
         ],
       };
@@ -716,30 +710,22 @@ describe("TrashGuide", async () => {
       const result = await loadTrashCFConflicts("RADARR");
 
       expect(result).toHaveLength(1);
-      expect(result[0]?.trash_id).toBe("group2");
+      expect(result[0]?.trash_id).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb+cccccccccccccccccccccccccccccccc");
       expect(result[0]?.custom_formats).toHaveLength(2);
     });
 
-    test("should skip invalid conflict entries", async () => {
+    test("should skip null and empty groups but load valid ones", async () => {
       const mockConflicts = {
         custom_formats: [
           {
-            trash_id: "group1",
-            name: "Valid Group",
-            custom_formats: [
-              { trash_id: "cf1", name: "CF1" },
-              { trash_id: "cf2", name: "CF2" },
-            ],
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: { name: "CF1", desc: "" },
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: { name: "CF2", desc: "" },
           },
           null,
-          { missing_fields: true },
+          {},
           {
-            trash_id: "group2",
-            name: "Valid Group 2",
-            custom_formats: [
-              { trash_id: "cf3", name: "CF3" },
-              { trash_id: "cf4", name: "CF4" },
-            ],
+            cccccccccccccccccccccccccccccccc: { name: "CF3", desc: "" },
+            dddddddddddddddddddddddddddddddd: { name: "CF4", desc: "" },
           },
         ],
       };
@@ -749,21 +735,16 @@ describe("TrashGuide", async () => {
       const result = await loadTrashCFConflicts("RADARR");
 
       expect(result).toHaveLength(2);
-      expect(result[0]?.trash_id).toBe("group1");
-      expect(result[1]?.trash_id).toBe("group2");
+      expect(result[0]?.trash_id).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+      expect(result[1]?.trash_id).toBe("cccccccccccccccccccccccccccccccc+dddddddddddddddddddddddddddddddd");
     });
 
-    test("should load valid conflict group with multiple CFs", async () => {
+    test("should normalize one group (desc join and trash_id sort order)", async () => {
       const mockConflicts = {
         custom_formats: [
           {
-            trash_id: "sdr-conflict",
-            name: "SDR Conflict Group",
-            trash_description: "SDR vs SDR (no WEBDL)",
-            custom_formats: [
-              { trash_id: "sdr-cf1", name: "SDR" },
-              { trash_id: "sdr-cf2", name: "SDR (no WEBDL)" },
-            ],
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: { name: "First alpha id", desc: "alpha" },
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: { name: "Second name", desc: "beta" },
           },
         ],
       };
@@ -773,24 +754,52 @@ describe("TrashGuide", async () => {
       const result = await loadTrashCFConflicts("RADARR");
 
       expect(result).toHaveLength(1);
-      expect(result[0]?.trash_id).toBe("sdr-conflict");
-      expect(result[0]?.name).toBe("SDR Conflict Group");
-      expect(result[0]?.trash_description).toBe("SDR vs SDR (no WEBDL)");
-      expect(result[0]?.custom_formats).toHaveLength(2);
-      expect(result[0]?.custom_formats[0]).toEqual({ trash_id: "sdr-cf1", name: "SDR" });
-      expect(result[0]?.custom_formats[1]).toEqual({ trash_id: "sdr-cf2", name: "SDR (no WEBDL)" });
+      expect(result[0]?.trash_id).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+      expect(result[0]?.name).toBe("First alpha id vs Second name");
+      expect(result[0]?.trash_description).toBe("alpha beta");
+      expect(result[0]?.custom_formats).toEqual([
+        { trash_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", name: "First alpha id" },
+        { trash_id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "Second name" },
+      ]);
+    });
+
+    test("should load conflicts.json matching TRaSH upstream sample", async () => {
+      const mockConflicts = {
+        $schema: "../../../schemas/conflicts.schema.json",
+        custom_formats: [
+          {
+            "9c38ebb7384dada637be8899efa68e6f": { name: "SDR", desc: "" },
+            "25c12f78430a3a23413652cbd1d48d77": { name: "SDR (no WEBDL)", desc: "" },
+          },
+          {
+            dc98083864ea246d05a42df0d05f81cc: { name: "x265 (HD)", desc: "a" },
+            "839bea857ed2c0a8e084f3cbdbd65ecb": { name: "x265 (no HDR/DV)", desc: "b" },
+          },
+        ],
+      };
+
+      vi.spyOn(util, "loadJsonFile").mockReturnValue(mockConflicts);
+
+      const result = await loadTrashCFConflicts("RADARR");
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.trash_id).toBe("25c12f78430a3a23413652cbd1d48d77+9c38ebb7384dada637be8899efa68e6f");
+      expect(result[0]?.name).toBe("SDR (no WEBDL) vs SDR");
+      expect(result[0]?.custom_formats).toEqual([
+        { trash_id: "25c12f78430a3a23413652cbd1d48d77", name: "SDR (no WEBDL)" },
+        { trash_id: "9c38ebb7384dada637be8899efa68e6f", name: "SDR" },
+      ]);
+      expect(result[1]?.trash_id).toBe("839bea857ed2c0a8e084f3cbdbd65ecb+dc98083864ea246d05a42df0d05f81cc");
+      expect(result[1]?.name).toBe("x265 (no HDR/DV) vs x265 (HD)");
+      expect(result[1]?.trash_description).toBe("b a");
     });
 
     test("should return cached conflicts when cache is ready", async () => {
       const mockConflicts = {
         custom_formats: [
           {
-            trash_id: "group1",
-            name: "Valid Group",
-            custom_formats: [
-              { trash_id: "cf1", name: "CF1" },
-              { trash_id: "cf2", name: "CF2" },
-            ],
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: { name: "CF1", desc: "" },
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: { name: "CF2", desc: "" },
           },
         ],
       };

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -407,7 +407,9 @@ export const loadTrashCFConflicts = async (arrType: TrashArrSupported): Promise<
 
       const keyCount = Object.keys(g.data).length;
       if (keyCount < 2) {
-        if (keyCount > 0) {
+        if (keyCount === 0) {
+          logger.debug(`(${arrType}) Skipping empty conflict group`);
+        } else {
           logger.warn(`(${arrType}) Skipping invalid conflict group: need at least 2 entries (string key -> { name, desc? })`);
         }
         continue;

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import { MergedCustomFormatResource } from "./types/merged.types";
 import { getConfig } from "./config";
 import { logger } from "./logger";
@@ -11,7 +12,6 @@ import {
   TrashCache,
   TrashCF,
   TrashCFConflict,
-  TrashCFConflicts,
   TrashCFGroupMapping,
   TrashCustomFormatGroups,
   TrashQP,
@@ -330,6 +330,41 @@ export const loadNamingFromTrashRadarr = async (): Promise<TrashRadarrNaming | n
   return firstValue;
 };
 
+/** Matches TRaSH conflicts.schema.json (object values: name required, desc optional, no extra keys). */
+const trashConflictCfEntrySchema = z
+  .object({
+    name: z.string(),
+    desc: z.string().optional(),
+  })
+  .strict();
+
+const trashConflictGroupRecordSchema = z.record(z.string(), trashConflictCfEntrySchema);
+
+const trashConflictsFileSchema = z
+  .object({
+    $schema: z.string().optional(),
+    custom_formats: z.array(z.unknown()),
+  })
+  .strict();
+
+const normalizeTrashConflictGroup = (group: z.infer<typeof trashConflictGroupRecordSchema>): TrashCFConflict => {
+  const entries = Object.entries(group).map(([trash_id, rec]) => ({
+    trash_id,
+    name: rec.name,
+    desc: rec.desc,
+  }));
+  entries.sort((a, b) => a.trash_id.localeCompare(b.trash_id));
+  const custom_formats = entries.map(({ trash_id, name }) => ({ trash_id, name }));
+  const descriptions = entries.map((e) => e.desc).filter((d): d is string => typeof d === "string" && d.length > 0);
+
+  return {
+    trash_id: custom_formats.map((cf) => cf.trash_id).join("+"),
+    name: custom_formats.map((cf) => cf.name).join(" vs "),
+    trash_description: descriptions.length > 0 ? descriptions.join(" ") : undefined,
+    custom_formats,
+  };
+};
+
 export const loadTrashCFConflicts = async (arrType: TrashArrSupported): Promise<TrashCFConflict[]> => {
   if (arrType !== "RADARR" && arrType !== "SONARR") {
     logger.debug(`Unsupported arrType: ${arrType}. Skipping TrashCFConflicts.`);
@@ -351,41 +386,34 @@ export const loadTrashCFConflicts = async (arrType: TrashArrSupported): Promise<
   }
 
   try {
-    const conflictsData = loadJsonFile<TrashCFConflicts>(conflictsPath);
+    const raw = loadJsonFile<unknown>(conflictsPath);
+    const fileParsed = trashConflictsFileSchema.safeParse(raw);
 
-    if (!conflictsData || !Array.isArray(conflictsData.custom_formats)) {
-      logger.warn(`(${arrType}) Invalid conflicts.json format: expected { custom_formats: [...] }. Skipping conflicts.`);
+    if (!fileParsed.success) {
+      logger.warn(`(${arrType}) Invalid conflicts.json: ${fileParsed.error.issues.map((i) => i.message).join("; ")}. Skipping conflicts.`);
       return [];
     }
 
-    for (const group of conflictsData.custom_formats) {
-      if (!group || typeof group !== "object") {
+    for (const group of fileParsed.data.custom_formats) {
+      if (group === null || typeof group !== "object" || Array.isArray(group)) {
         continue;
       }
 
-      // Validate required fields
-      if (typeof group.trash_id !== "string" || typeof group.name !== "string" || !Array.isArray(group.custom_formats)) {
-        logger.warn(`(${arrType}) Skipping invalid conflict group: missing or invalid trash_id, name, or custom_formats`);
+      const g = trashConflictGroupRecordSchema.safeParse(group);
+      if (!g.success) {
+        logger.warn(`(${arrType}) Skipping invalid conflict group: ${g.error.issues.map((i) => i.message).join("; ")}`);
         continue;
       }
 
-      // Filter and validate custom_formats with type predicate
-      const customFormats = group.custom_formats.filter(
-        (cf): cf is { trash_id: string; name: string } =>
-          typeof cf === "object" && cf !== null && typeof cf.trash_id === "string" && typeof cf.name === "string",
-      );
-
-      if (customFormats.length < 2) {
-        // Conflict groups need at least 2 CFs to be meaningful
+      const keyCount = Object.keys(g.data).length;
+      if (keyCount < 2) {
+        if (keyCount > 0) {
+          logger.warn(`(${arrType}) Skipping invalid conflict group: need at least 2 entries (string key -> { name, desc? })`);
+        }
         continue;
       }
 
-      conflicts.push({
-        trash_id: group.trash_id,
-        name: group.name,
-        trash_description: typeof group.trash_description === "string" ? group.trash_description : undefined,
-        custom_formats: customFormats,
-      });
+      conflicts.push(normalizeTrashConflictGroup(g.data));
     }
 
     logger.debug(`(${arrType}) Loaded ${conflicts.length} TRaSH CF conflict groups`);

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -60,6 +60,7 @@ export type CFIDToConfigGroup = Map<string, CFConfigGroup>;
 
 export type CFProcessing = {
   carrIdMapping: CFIDToConfigGroup;
+  /** Last merge-order winner per CF `name` (same row Sonarr/Radarr); used by manageCf. */
   cfNameToCarrConfig: Map<string, ConfigarrCF>;
 };
 

--- a/src/types/trashguide.types.ts
+++ b/src/types/trashguide.types.ts
@@ -158,8 +158,8 @@ export type TrashCustomFormatGroups = {
 export type TrashCFGroupMapping = Map<string, TrashCustomFormatGroups>;
 
 /**
- * A single custom format conflict group from TRaSH conflicts.json.
- * Each group represents mutually exclusive custom formats.
+ * Runtime representation of one TRaSH conflict group (mutually exclusive custom formats).
+ * Built from conflicts.json by normalizing each `custom_formats` array entry.
  */
 export type TrashCFConflict = {
   trash_id: string;
@@ -169,11 +169,4 @@ export type TrashCFConflict = {
     trash_id: string;
     name: string;
   }>;
-};
-
-/**
- * Top-level structure of conflicts.json file.
- */
-export type TrashCFConflicts = {
-  custom_formats: TrashCFConflict[];
 };


### PR DESCRIPTION
* happens with custom format definitions

## Summary by Sourcery

Handle custom formats with conflicting names by selecting a single winner per name, normalizing TRaSH conflicts.json loading, and updating CF management to operate per CF name instead of per trash_id.

Bug Fixes:
- Ensure only one winning custom format is used when multiple trash_ids share the same CF name, with clear logging when definitions differ.

Enhancements:
- Refine TRaSH conflicts.json parsing to validate against the upstream schema, normalize conflict groups into a stable, sorted representation, and ignore invalid or underspecified groups.
- Change custom format management to operate based on CF names and the merge winner mapping, avoiding duplicate updates and ensuring consistent server synchronization.

Tests:
- Add coverage for conflict resolution when multiple trash_ids map to the same CF name, including logging behavior and winner selection.
- Expand TrashGuide conflict-loading tests to cover null/empty groups, schema-conforming conflicts.json samples, normalization of group IDs, names, and descriptions, and cache behavior.