### PR TITLE
feat: add silenceTrashConflictWarnings config option

### DIFF
--- a/docs/docs/configuration/_include/config-file-sample.yml
+++ b/docs/docs/configuration/_include/config-file-sample.yml
@@ -16,6 +16,11 @@
 # See: https://github.com/TRaSH-Guides/Guides/commit/2994a7979d8036a7908a92e2cd286054fd4fcc1b
 #compatibilityTrashGuide20260219Enabled: false
 
+# Optional. Silence warnings when a Quality Profile contains CustomFormats marked mutually
+# exclusive in TRaSH-Guides conflicts.json. Sync behavior is unchanged; only logs are suppressed.
+# Default is false.
+#silenceTrashConflictWarnings: true
+
 # Optional: Enable anonymous telemetry tracking of feature usage
 # Default is false. Set to true to help improve Configarr by sharing anonymous usage statistics.
 telemetry: true

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -223,6 +223,27 @@ telemetry: true
 
 **Note:** Telemetry is disabled by default and is completely opt-in. See [Telemetry](./telemetry.md)
 
+### TRaSH CustomFormat conflicts <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.26.0</span> {#trash-cf-conflicts}
+
+Configarr parses `conflicts.json` from TRaSH-Guides and logs a warning when a Quality Profile
+is configured with two or more CustomFormats that TRaSH marks as mutually exclusive. Sync
+behavior is **not** changed — the warning is informational only, so you can review whether
+the combination is intentional.
+
+The check runs automatically for Radarr and Sonarr instances whenever `conflicts.json` is
+available in the TRaSH-Guides repository.
+
+#### Silence conflict warnings <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.27.0</span> {#silence-trash-conflict-warnings}
+
+If you intentionally configure conflicting CustomFormats (or simply want quieter logs), set
+the top-level flag to skip the check:
+
+```yaml
+silenceTrashConflictWarnings: true
+```
+
+Default is `false`. Sync behavior is identical either way — only the warning log is suppressed.
+
 ### Sharing download client config with YAML anchors <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.23.0</span> {#yaml-anchors}
 
 You can avoid repeating the same download client settings by using **YAML anchors** and **merge keys**:

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ const pipeline = async (globalConfig: InputConfigSchema, instanceConfig: InputCo
   const mergedCFs = await loadCustomFormatDefinitions(idsToManage, arrType, config.customFormatDefinitions || []);
 
   // Check for conflicting CFs from TRaSH guides
-  if (isInConstArray(TrashArrSupportedConst, arrType)) {
+  if (isInConstArray(TrashArrSupportedConst, arrType) && !globalConfig.silenceTrashConflictWarnings) {
     const conflicts = await loadTrashCFConflicts(arrType as TrashArrSupported);
     checkForConflictingCFs(mergedCFs, config, conflicts);
   }

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -27,6 +27,13 @@ export type InputConfigSchema = {
    * @temporary This option will be removed in a future version
    */
   compatibilityTrashGuide20260219Enabled?: boolean;
+  /**
+   * Silences warnings emitted when a Quality Profile contains CustomFormats that TRaSH-Guides
+   * marks as mutually exclusive in `conflicts.json`. Sync behavior itself is not changed — only
+   * the log output is suppressed. Useful when conflicting CFs are intentionally configured.
+   * @default false
+   */
+  silenceTrashConflictWarnings?: boolean;
 
   sonarr?: Record<string, InputConfigArrInstance>;
   sonarrEnabled?: boolean;


### PR DESCRIPTION
Gates the per-QualityProfile warning about mutually exclusive CFs from TRaSH conflicts.json. Sync behavior is unchanged.

## Summary by Sourcery

Add a configurable option to silence TRaSH conflicts warnings while leaving sync behavior unchanged.

New Features:
- Introduce a silenceTrashConflictWarnings config flag to disable logging of mutually exclusive CustomFormat warnings from TRaSH conflicts.json.

Documentation:
- Document the new silenceTrashConflictWarnings option in the sample configuration file.