### PR TITLE
feat: improve handling of TRaSH CF groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ Each feature (quality profiles, custom formats, metadata profiles, root folders)
 
 ## Important Notes
 
+- **Never edit `CHANGELOG.md` manually** — it is created and maintained by CI/CD (e.g. release automation). Do not add, remove, or rewrite changelog entries by hand; describe user-facing changes in PRs/commits so the pipeline can record them.
 - **Never commit without passing all checks**: build, test, lint, typecheck
 - **Always use pnpm** - not npm or yarn
 - **Backward compatibility** - Maintain existing APIs when refactoring

--- a/docs/docs/configuration/_include/config-file-sample.yml
+++ b/docs/docs/configuration/_include/config-file-sample.yml
@@ -21,6 +21,9 @@
 # Default is false.
 #silenceTrashConflictWarnings: true
 
+# since v1.28.0. Optional. Silence warnings when custom_format_groups excludes a CF that TRaSH marks as required.
+#silenceRequiredCfGroupExclusionWarnings: true
+
 # Optional: Enable anonymous telemetry tracking of feature usage
 # Default is false. Set to true to help improve Configarr by sharing anonymous usage statistics.
 telemetry: true
@@ -168,7 +171,7 @@ sonarr:
     #    check_for_finished_download_interval: 5
     #    # Note: auto_redownload_failed_from_interactive_search is not available in Whisparr
 
-    # (experimental) since v1.12.0
+    # (experimental) custom_format_groups since v1.12.0; expanded cf-group options since v1.28.0
     # allows using the cf-groups from TRaSH-Guide.
     custom_format_groups:
       - trash_guide:

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -693,7 +693,7 @@ TRaSH-Guide describes optional CFs and defaults per [cf-groups](https://github.c
 
 - **Default expansion** (no `include` key): includes each CF in the group where `required: true` **or** `default: true` / `"true"` (same idea as TRaSH default-checked optional CFs).
 - **`include_unrequired: true`**: includes **every** CF listed in the group JSON for that group reference (full group contents).
-- **`include`**: optional allow-list of `{ id: <CF trash_id> }`. Only those CFs are taken from the group (they must exist in the group). Mutually exclusive with “default expansion” for that reference — if `include` is set (even `[]`), only listed IDs are used.
+- **`include`**: optional additive list of `{ id: <CF trash_id> }`. Listed IDs are added on top of the base selection (they must exist in the group). This is mainly useful to add non-default optional CFs without enabling full `include_unrequired`.
 - **`exclude`**: optional list of `{ id: <CF trash_id> }` removed after selection. If the same `trash_id` appears in both `include` and `exclude`, **`exclude` wins**.
 - Listing an **`exclude`** id that TRaSH marks as **`required: true`** logs a **warning** by default (you intentionally omit that CF). Set top-level `silenceRequiredCfGroupExclusionWarnings: true` to suppress that warning (sync behavior unchanged).
 
@@ -714,29 +714,27 @@ Precedence:
 
 1. Base auto selection from TRaSH default groups (`required`, plus optional `default` CFs when enabled)
 2. `trash_cfgroup_include_unrequired` (if true, start from all CFs in matched groups)
-3. `trash_cfgroup_include_cfs` (if provided, allow-list mode)
+3. `trash_cfgroup_include_cfs` (if provided, additive merge on top of current selection)
 4. `trash_cfgroup_exclude_cfs` (always last, wins over include)
 
 If a required CF is excluded, Configarr logs a warning by default (same warning control via `silenceRequiredCfGroupExclusionWarnings`).
 
 <MermaidPanZoom
-  id="trash-auto-cf-group-overrides"
-  chart={`
-flowchart LR
+id="trash-auto-cf-group-overrides"
+chart={`flowchart LR
   A["TRASH include"] --> B["Resolve defaults"]
   B --> C["Base selection\\nrequired + optional default"]
   C --> D{"include_unrequired?"}
   D -->|yes| E["All CFs from groups"]
   D -->|no| F{"include_cfs given?"}
   E --> F
-  F -->|yes| G["Allow-list only"]
+  F -->|yes| G["Add include_cfs IDs"]
   F -->|no| H["Apply exclude_cfs\\n(exclude wins)"]
   G --> H
   H --> I{"Excluded CF required?"}
   I -->|yes| J["Warn or silence"]
   I -->|no| K["Final CF set"]
-  J --> K
-`}
+  J --> K`}
 />
 
 ```yaml
@@ -768,7 +766,7 @@ sonarr:
       - trash_guide:
           - id: c4735e1d02e8738044ad4ad1bf58670c
             # include_unrequired: true   # load every CF in this group
-            # include:                   # or restrict to specific CF trash_ids
+            # include:                   # add specific CF trash_ids
             #   - id: abc...
             # exclude:                   # drop CFs after selection (wins over include)
             #   - id: def...

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -51,6 +51,7 @@ Configarr supports multiple types of templates:
    - You must also check all CF-Groups because they will be also included automatically (this is desired by the TRaSH-Guide)
      - [TRaSH-Guides Radarr CF Groups](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/radarr/cf-groups)
      - [TRaSH-Guides Sonarr CF Groups](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/sonarr/cf-groups)
+     - Finer control over auto-loaded default CF-groups (`trash_cfgroup_*`, warning suppression, expanded `custom_format_groups` semantics) requires [**v1.28.0**](https://github.com/raydak-labs/configarr/releases/tag/v1.28.0) or newer — see [CustomFormatGroups](#custom-format-groups).
      - [Github PR/Explanation](https://github.com/TRaSH-Guides/Guides/pull/2455#discussion_r2297832409)
      - [Discord Discussion/Explanation](https://discord.com/channels/492590071455940612/1409911784386596894)
 
@@ -683,11 +684,17 @@ Notes:
 
 - **experimental**, available since `v1.18.0`
 
-## CustomFormatGroups {#custom-format-groups}
+## CustomFormatGroups <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.12.0</span> {#custom-format-groups}
 
 Support has been added to allow using the TRaSH-Guide custom format groups: [see here](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/sonarr/cf-groups).
 Those are logically bundled together CustomFormats which will be applied together.
 TRaSH-Guide describes optional CFs and defaults per [cf-groups](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md#cf-groups).
+
+:::info Version notes
+
+Listing TRaSH cf-groups under `custom_format_groups` has been supported since **`v1.12.0`** (experimental). The **expanded TRaSH cf-group handling** in this section—including additive `include`, default/`include_unrequired`/`exclude` behavior, `silenceRequiredCfGroupExclusionWarnings`, and `trash_cfgroup_*` auto-group overrides—requires [**v1.28.0**](https://github.com/raydak-labs/configarr/releases/tag/v1.28.0) or newer.
+
+:::
 
 **When you reference a group** (`custom_format_groups`), Configarr expands TRaSH IDs into CF assignments like this:
 
@@ -700,14 +707,14 @@ TRaSH-Guide describes optional CFs and defaults per [cf-groups](https://github.c
 The **`quality_profiles`** block inside TRaSH cf-group JSON **does not apply** to `custom_format_groups` in config — it is only used when Configarr auto-applies **default** groups for included TRaSH quality profiles.
 For that automatic path, you can configure defaults at the instance level and override per TRaSH include item.
 
-### TRASH Auto CF-Group Overrides (Experimental) {#trash-auto-cf-group-overrides}
+### TRaSH Auto CF-Group Overrides <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.28.0</span> (Experimental) {#trash-auto-cf-group-overrides}
 
-This feature is **experimental** and may change in future releases.
+This feature is **experimental**, shipped in [**v1.28.0**](https://github.com/raydak-labs/configarr/releases/tag/v1.28.0), and may change in future releases.
 
 When using `include` with `source: TRASH` (quality profile JSON), Configarr auto-loads CFs from TRaSH default CF-groups.
 You can now influence this behavior:
 
-- **Instance-level defaults** under `trash_cfgroup_config` (apply to all TRASH profile includes in that instance)
+- **Instance-level defaults** under `trash_cfgroup_config` (apply to all TRaSH profile includes in that instance)
 - **Include-item overrides** (apply only to one include entry)
 
 Precedence:
@@ -760,7 +767,7 @@ sonarr:
       exclude_cfs:
         - id: example-cf-id
 
-    # (experimental) since v1.12.0
+    # (experimental) custom_format_groups since v1.12.0; expanded cf-group options below since v1.28.0
     # allows using the cf-groups from TRaSH-Guide.
     custom_format_groups:
       - trash_guide:
@@ -788,7 +795,7 @@ sonarr:
 
 Notes:
 
-- **experimental**, available since `v1.12.0`
+- **experimental** — `custom_format_groups` since `v1.12.0`; expanded TRaSH cf-group behavior and `trash_cfgroup_*` overrides in this section since **`v1.28.0`**.
 
 ### TRaSH-Guides Breaking Changes (Feb 2026) {#trash-guides-breaking-changes-2026-02}
 

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -8,6 +8,7 @@ keywords: [configarr configuration, yaml config, secrets management, custom form
 import CodeBlock from "@theme/CodeBlock";
 import ConfigFileSample from "!!raw-loader!./\_include/config-file-sample.yml";
 import ExampleUnamanagedCustomFormats from "!!raw-loader!./\_include/unmanaged-customformats.yml";
+import MermaidPanZoom from "@site/src/components/MermaidPanZoom";
 
 # Configuration Files
 
@@ -718,18 +719,25 @@ Precedence:
 
 If a required CF is excluded, Configarr logs a warning by default (same warning control via `silenceRequiredCfGroupExclusionWarnings`).
 
-```mermaid
-flowchart TD
-  includeTrash["TRASH include item"]
-  matchGroups["Match default CF groups for profile"]
-  baseSel["Base select: required (+ optional default if enabled)"]
-  unrequired["include_unrequired? -> use all CFs"]
-  includeList["include_cfs provided? -> allow-list"]
-  excludeList["exclude_cfs -> remove IDs"]
-  result["Auto CF group output for this include"]
-
-  includeTrash --> matchGroups --> baseSel --> unrequired --> includeList --> excludeList --> result
-```
+<MermaidPanZoom
+  id="trash-auto-cf-group-overrides"
+  chart={`
+flowchart LR
+  A["TRASH include"] --> B["Resolve defaults"]
+  B --> C["Base selection\\nrequired + optional default"]
+  C --> D{"include_unrequired?"}
+  D -->|yes| E["All CFs from groups"]
+  D -->|no| F{"include_cfs given?"}
+  E --> F
+  F -->|yes| G["Allow-list only"]
+  F -->|no| H["Apply exclude_cfs\\n(exclude wins)"]
+  G --> H
+  H --> I{"Excluded CF required?"}
+  I -->|yes| J["Warn or silence"]
+  I -->|no| K["Final CF set"]
+  J --> K
+`}
+/>
 
 ```yaml
 # Optional: suppress warnings when excluding required CFs from a group (see above)

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -697,7 +697,39 @@ TRaSH-Guide describes optional CFs and defaults per [cf-groups](https://github.c
 - Listing an **`exclude`** id that TRaSH marks as **`required: true`** logs a **warning** by default (you intentionally omit that CF). Set top-level `silenceRequiredCfGroupExclusionWarnings: true` to suppress that warning (sync behavior unchanged).
 
 The **`quality_profiles`** block inside TRaSH cf-group JSON **does not apply** to `custom_format_groups` in config — it is only used when Configarr auto-applies **default** groups for included TRaSH quality profiles.
-For that automatic path, you can set `includeDefaultOptionalTrashGroupCfs: false` on an instance to include only TRaSH `required: true` CFs (skip optional `default: true` CFs).
+For that automatic path, you can configure defaults on instance-level and override per TRASH include item.
+
+### TRASH Auto CF-Group Overrides (Experimental) {#trash-auto-cf-group-overrides}
+
+This feature is **experimental** and may change in future releases.
+
+When using `include` with `source: TRASH` (quality profile JSON), Configarr auto-loads CFs from TRaSH default CF-groups.
+You can now influence this behavior:
+
+- **Instance-level defaults** (apply to all TRASH profile includes in that instance)
+- **Include-item overrides** (apply only to one include entry)
+
+Precedence:
+
+1. Base auto selection from TRaSH default groups (`required`, plus optional `default` CFs when enabled)
+2. `trash_cfgroup_include_unrequired` (if true, start from all CFs in matched groups)
+3. `trash_cfgroup_include_cfs` (if provided, allow-list mode)
+4. `trash_cfgroup_exclude_cfs` (always last, wins over include)
+
+If a required CF is excluded, Configarr logs a warning by default (same warning control via `silenceRequiredCfGroupExclusionWarnings`).
+
+```mermaid
+flowchart TD
+  includeTrash["TRASH include item"]
+  matchGroups["Match default CF groups for profile"]
+  baseSel["Base select: required (+ optional default if enabled)"]
+  unrequired["include_unrequired? -> use all CFs"]
+  includeList["include_cfs provided? -> allow-list"]
+  excludeList["exclude_cfs -> remove IDs"]
+  result["Auto CF group output for this include"]
+
+  includeTrash --> matchGroups --> baseSel --> unrequired --> includeList --> excludeList --> result
+```
 
 ```yaml
 # Optional: suppress warnings when excluding required CFs from a group (see above)
@@ -709,10 +741,17 @@ sonarr:
   instance1:
     # ...
 
-    # Optional per-instance behavior for TRASH profile includes:
-    # true (default): auto-load required + default optional CFs from default TRaSH groups
-    # false: auto-load only required CFs from default TRaSH groups
-    includeDefaultOptionalTrashGroupCfs: true
+    # Experimental instance-level defaults for TRASH auto CF-group loading
+    # optional: true (default)
+    trash_cfgroup_include_optional: true
+    # optional: false (default)
+    trash_cfgroup_include_unrequired: false
+    # optional: [] (default)
+    trash_cfgroup_include_cfs:
+      - id: example-cf-id
+    # optional: [] (default)
+    trash_cfgroup_exclude_cfs:
+      - id: example-cf-id
 
     # (experimental) since v1.12.0
     # allows using the cf-groups from TRaSH-Guide.
@@ -727,6 +766,17 @@ sonarr:
         assign_scores_to:
           - name: MyProfile
             # score: 0 # optional score for all CFs from this group row; override per CF via custom_formats
+
+    include:
+      - template: 2b90e905c99490edc7c7a5787443748b
+        source: TRASH
+        # Experimental per-include overrides (override instance defaults)
+        trash_cfgroup_include_optional: false
+        trash_cfgroup_include_unrequired: false
+        trash_cfgroup_include_cfs:
+          - id: some-cf-id
+        trash_cfgroup_exclude_cfs:
+          - id: another-cf-id
 ```
 
 Notes:

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -706,7 +706,7 @@ This feature is **experimental** and may change in future releases.
 When using `include` with `source: TRASH` (quality profile JSON), Configarr auto-loads CFs from TRaSH default CF-groups.
 You can now influence this behavior:
 
-- **Instance-level defaults** (apply to all TRASH profile includes in that instance)
+- **Instance-level defaults** under `trash_cfgroup_config` (apply to all TRASH profile includes in that instance)
 - **Include-item overrides** (apply only to one include entry)
 
 Precedence:
@@ -742,16 +742,17 @@ sonarr:
     # ...
 
     # Experimental instance-level defaults for TRASH auto CF-group loading
-    # optional: true (default)
-    trash_cfgroup_include_optional: true
-    # optional: false (default)
-    trash_cfgroup_include_unrequired: false
-    # optional: [] (default)
-    trash_cfgroup_include_cfs:
-      - id: example-cf-id
-    # optional: [] (default)
-    trash_cfgroup_exclude_cfs:
-      - id: example-cf-id
+    trash_cfgroup_config:
+      # optional: true (default)
+      include_optional: true
+      # optional: false (default)
+      include_unrequired: false
+      # optional: [] (default)
+      include_cfs:
+        - id: example-cf-id
+      # optional: [] (default)
+      exclude_cfs:
+        - id: example-cf-id
 
     # (experimental) since v1.12.0
     # allows using the cf-groups from TRaSH-Guide.

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -698,7 +698,7 @@ TRaSH-Guide describes optional CFs and defaults per [cf-groups](https://github.c
 - Listing an **`exclude`** id that TRaSH marks as **`required: true`** logs a **warning** by default (you intentionally omit that CF). Set top-level `silenceRequiredCfGroupExclusionWarnings: true` to suppress that warning (sync behavior unchanged).
 
 The **`quality_profiles`** block inside TRaSH cf-group JSON **does not apply** to `custom_format_groups` in config — it is only used when Configarr auto-applies **default** groups for included TRaSH quality profiles.
-For that automatic path, you can configure defaults on instance-level and override per TRASH include item.
+For that automatic path, you can configure defaults at the instance level and override per TRaSH include item.
 
 ### TRASH Auto CF-Group Overrides (Experimental) {#trash-auto-cf-group-overrides}
 
@@ -722,7 +722,7 @@ If a required CF is excluded, Configarr logs a warning by default (same warning 
 <MermaidPanZoom
 id="trash-auto-cf-group-overrides"
 chart={`flowchart LR
-  A["TRASH include"] --> B["Resolve defaults"]
+  A["TRaSH include"] --> B["Resolve defaults"]
   B --> C["Base selection\\nrequired + optional default"]
   C --> D{"include_unrequired?"}
   D -->|yes| E["All CFs from groups"]
@@ -747,7 +747,7 @@ sonarr:
   instance1:
     # ...
 
-    # Experimental instance-level defaults for TRASH auto CF-group loading
+    # Experimental instance-level defaults for TRaSH auto CF-group loading
     trash_cfgroup_config:
       # optional: true (default)
       include_optional: true

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -686,29 +686,47 @@ Notes:
 
 Support has been added to allow using the TRaSH-Guide custom format groups: [see here](https://github.com/TRaSH-Guides/Guides/tree/master/docs/json/sonarr/cf-groups).
 Those are logically bundled together CustomFormats which will be applied together.
-TRaSH-Guide is using them in an interactive manner with Notifiarr therefore there are also non required CustomFormats.
-Configarr will only load required ones (`required: true`).
+TRaSH-Guide describes optional CFs and defaults per [cf-groups](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md#cf-groups).
 
-If you need some optional ones just add them with the existing `custom_formats` mapping.
-Also the `quality_profiles` mapping in the JSON file is ignored because it does not make sense in Configarr.
+**When you reference a group** (`custom_format_groups`), Configarr expands TRaSH IDs into CF assignments like this:
 
-```yml
+- **Default expansion** (no `include` key): includes each CF in the group where `required: true` **or** `default: true` / `"true"` (same idea as TRaSH default-checked optional CFs).
+- **`include_unrequired: true`**: includes **every** CF listed in the group JSON for that group reference (full group contents).
+- **`include`**: optional allow-list of `{ id: <CF trash_id> }`. Only those CFs are taken from the group (they must exist in the group). Mutually exclusive with “default expansion” for that reference — if `include` is set (even `[]`), only listed IDs are used.
+- **`exclude`**: optional list of `{ id: <CF trash_id> }` removed after selection. If the same `trash_id` appears in both `include` and `exclude`, **`exclude` wins**.
+- Listing an **`exclude`** id that TRaSH marks as **`required: true`** logs a **warning** by default (you intentionally omit that CF). Set top-level `silenceRequiredCfGroupExclusionWarnings: true` to suppress that warning (sync behavior unchanged).
+
+The **`quality_profiles`** block inside TRaSH cf-group JSON **does not apply** to `custom_format_groups` in config — it is only used when Configarr auto-applies **default** groups for included TRaSH quality profiles.
+For that automatic path, you can set `includeDefaultOptionalTrashGroupCfs: false` on an instance to include only TRaSH `required: true` CFs (skip optional `default: true` CFs).
+
+```yaml
+# Optional: suppress warnings when excluding required CFs from a group (see above)
+silenceRequiredCfGroupExclusionWarnings: false
+
 # ...
 
 sonarr:
   instance1:
     # ...
 
+    # Optional per-instance behavior for TRASH profile includes:
+    # true (default): auto-load required + default optional CFs from default TRaSH groups
+    # false: auto-load only required CFs from default TRaSH groups
+    includeDefaultOptionalTrashGroupCfs: true
+
     # (experimental) since v1.12.0
     # allows using the cf-groups from TRaSH-Guide.
     custom_format_groups:
       - trash_guide:
-          - id: c4735e1d02e8738044ad4ad1bf58670c # Multiple CFs, only where required=true are loaded
-            #include_unrequired: true # if you want to load all set this to true
+          - id: c4735e1d02e8738044ad4ad1bf58670c
+            # include_unrequired: true   # load every CF in this group
+            # include:                   # or restrict to specific CF trash_ids
+            #   - id: abc...
+            # exclude:                   # drop CFs after selection (wins over include)
+            #   - id: def...
         assign_scores_to:
           - name: MyProfile
-            # (experimental) since v1.16.0
-            #score: 0 # optional score to assign to all custom formats in this group. You can still override custom format scores via custom_formats
+            # score: 0 # optional score for all CFs from this group row; override per CF via custom_formats
 ```
 
 Notes:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -27,6 +27,7 @@ const config: Config = {
       onBrokenMarkdownLinks: "warn",
     },
   },
+  themes: ["@docusaurus/theme-mermaid"],
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -22,6 +22,7 @@ const config: Config = {
 
   onBrokenLinks: "throw",
   markdown: {
+    mermaid: true,
     hooks: {
       onBrokenMarkdownLinks: "warn",
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,10 +17,13 @@
   "dependencies": {
     "@docusaurus/core": "3.10.0",
     "@docusaurus/preset-classic": "3.10.0",
+    "@docusaurus/theme-mermaid": "3.10.0",
     "@mdx-js/react": "3.1.1",
+    "@panzoom/panzoom": "^4.6.2",
     "clsx": "2.1.1",
     "docusaurus-lunr-search": "3.6.1",
     "lunr": "2.3.9",
+    "mermaid": "^11.14.0",
     "prism-react-renderer": "2.4.1",
     "raw-loader": "4.0.2",
     "react": "19.2.5",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -10,22 +10,31 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: 3.10.0
-        version: 3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)
+        version: 3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)
+      '@docusaurus/theme-mermaid':
+        specifier: 3.10.0
+        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: 3.1.1
         version: 3.1.1(@types/react@18.3.12)(react@19.2.5)
+      '@panzoom/panzoom':
+        specifier: ^4.6.2
+        version: 4.6.2
       clsx:
         specifier: 2.1.1
         version: 2.1.1
       docusaurus-lunr-search:
         specifier: 3.6.1
-        version: 3.6.1(@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.6.1(@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lunr:
         specifier: 2.3.9
         version: 2.3.9
+      mermaid:
+        specifier: ^11.14.0
+        version: 11.14.0
       prism-react-renderer:
         specifier: 2.4.1
         version: 2.4.1(react@19.2.5)
@@ -41,13 +50,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.0
-        version: 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/tsconfig':
         specifier: 3.10.0
         version: 3.10.0
       '@docusaurus/types':
         specifier: 3.10.0
-        version: 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -150,6 +159,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -715,6 +727,24 @@ packages:
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/cst-dts-gen@12.0.0':
+    resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
+
+  '@chevrotain/gast@12.0.0':
+    resolution: {integrity: sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==}
+
+  '@chevrotain/regexp-to-ast@12.0.0':
+    resolution: {integrity: sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==}
+
+  '@chevrotain/types@12.0.0':
+    resolution: {integrity: sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==}
+
+  '@chevrotain/utils@12.0.0':
+    resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1143,6 +1173,17 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  '@docusaurus/theme-mermaid@3.10.0':
+    resolution: {integrity: sha512-Y2xrlwhIJ80oOZIO3PXL6A7J869splfcMI87E3NKpYsy3zJxOyV+BP1QMtGi59ajKgU868HPuyyn6J+6BZGOBg==}
+    engines: {node: '>=20.0'}
+    peerDependencies:
+      '@mermaid-js/layout-elk': ^0.1.9
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@mermaid-js/layout-elk':
+        optional: true
+
   '@docusaurus/theme-search-algolia@3.10.0':
     resolution: {integrity: sha512-f5FPKI08e3JRG63vR/o4qeuUVHUHzFzM0nnF+AkB67soAZgNsKJRf2qmUZvlQkGwlV+QFkKe4D0ANMh1jToU3g==}
     engines: {node: '>=20.0'}
@@ -1180,6 +1221,12 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.1':
+    resolution: {integrity: sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -1258,6 +1305,9 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@mermaid-js/parser@1.1.0':
+    resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1269,6 +1319,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@panzoom/panzoom@4.6.2':
+    resolution: {integrity: sha512-Zn3B5/hwa6eYIPRSKX0xf2clv8nviTX8AnAU5kU/EugiTDhG41ya2wlBqYrZJYCWQROr/5XkWObZhIkepi89qw==}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1415,6 +1468,99 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1438,6 +1584,9 @@ packages:
 
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/gtag.js@0.0.20':
     resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
@@ -1541,6 +1690,9 @@ packages:
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1558,6 +1710,9 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -1628,6 +1783,11 @@ packages:
 
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1896,6 +2056,15 @@ packages:
     resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
     engines: {node: '>= 6'}
 
+  chevrotain-allstar@0.4.3:
+    resolution: {integrity: sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==}
+    peerDependencies:
+      chevrotain: ^12.0.0
+
+  chevrotain@12.0.0:
+    resolution: {integrity: sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==}
+    engines: {node: '>=22.0.0'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -1995,6 +2164,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -2053,6 +2225,12 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -2192,6 +2370,165 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.3:
+    resolution: {integrity: sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -2254,6 +2591,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -2321,6 +2661,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -2682,6 +3025,9 @@ packages:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
@@ -2863,6 +3209,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   icss-utils@5.1.0:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
@@ -2919,6 +3269,13 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -3128,8 +3485,15 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -3139,12 +3503,22 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  langium@4.2.3:
+    resolution: {integrity: sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
   latest-version@7.0.0:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
 
   launch-editor@2.9.1:
     resolution: {integrity: sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -3168,6 +3542,9 @@ packages:
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -3216,6 +3593,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdast-util-directive@3.0.0:
     resolution: {integrity: sha512-JUpYOqKI4mM3sZcNxmF/ox04XYFFkNwr0CFlrQIkCwbvH0xzMCqkMqAde9wRd80VAhaUrwFwKm2nxretdT1h7Q==}
@@ -3293,6 +3675,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.14.0:
+    resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -3488,6 +3873,9 @@ packages:
     resolution: {integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==}
     deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
@@ -3646,6 +4034,9 @@ packages:
     resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
     engines: {node: '>=14.16'}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -3679,6 +4070,9 @@ packages:
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3706,6 +4100,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3716,6 +4113,15 @@ packages:
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-attribute-case-insensitive@7.0.1:
     resolution: {integrity: sha512-Uai+SupNSqzlschRyNx3kbCTWgY/2hcwtHEI/ej2LJWc9JJ77qKgGptd8DHwY1mXtZ7Aoh4z4yxfwMBue9eNgw==}
@@ -4371,6 +4777,12 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   rtlcss@4.3.0:
     resolution: {integrity: sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig==}
     engines: {node: '>=12.0.0'}
@@ -4382,6 +4794,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -4626,6 +5041,9 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4686,6 +5104,10 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinypool@1.1.0:
     resolution: {integrity: sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4720,6 +5142,10 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4746,6 +5172,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -4858,6 +5287,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -4887,6 +5320,26 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
@@ -5185,6 +5638,11 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -5938,6 +6396,23 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/cst-dts-gen@12.0.0':
+    dependencies:
+      '@chevrotain/gast': 12.0.0
+      '@chevrotain/types': 12.0.0
+
+  '@chevrotain/gast@12.0.0':
+    dependencies:
+      '@chevrotain/types': 12.0.0
+
+  '@chevrotain/regexp-to-ast@12.0.0': {}
+
+  '@chevrotain/types@12.0.0': {}
+
+  '@chevrotain/utils@12.0.0': {}
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -6220,7 +6695,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.2
@@ -6232,7 +6707,7 @@ snapshots:
       '@babel/runtime': 7.26.0
       '@babel/traverse': 7.25.9
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.2.0
       tslib: 2.8.1
@@ -6246,14 +6721,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/bundler@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.26.0
-      '@docusaurus/babel': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/babel': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1)
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.96.1)
@@ -6288,15 +6763,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/bundler': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/babel': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/bundler': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -6364,12 +6839,12 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/mdx-loader@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.2.1
@@ -6400,9 +6875,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/module-type-aliases@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -6419,17 +6894,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -6462,17 +6937,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
@@ -6503,13 +6978,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.2.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -6534,12 +7009,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -6562,11 +7037,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.2.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -6591,11 +7066,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -6618,11 +7093,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -6646,11 +7121,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -6673,14 +7148,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.2.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -6705,12 +7180,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.5
@@ -6736,23 +7211,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-classic': 3.10.0(@types/react@18.3.12)(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-classic': 3.10.0(@types/react@18.3.12)(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -6782,21 +7257,21 @@ snapshots:
       '@types/react': 18.3.12
       react: 19.2.5
 
-  '@docusaurus/theme-classic@3.10.0(@types/react@18.3.12)(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/theme-classic@3.10.0(@types/react@18.3.12)(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -6831,13 +7306,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -6856,17 +7331,48 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)':
+  '@docusaurus/theme-mermaid@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+    dependencies:
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      mermaid: 11.14.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@docusaurus/faster'
+      - '@docusaurus/plugin-content-docs'
+      - '@mdx-js/react'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - acorn
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(@types/react@18.3.12)(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)(typescript@6.0.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.39.0)(algoliasearch@5.39.0)(search-insights@2.17.2)
       '@docsearch/react': 3.9.0(@algolia/client-search@5.39.0)(@types/react@18.3.12)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.2)
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       algoliasearch: 5.39.0
       algoliasearch-helper: 3.26.0(algoliasearch@5.39.0)
       clsx: 2.1.1
@@ -6906,9 +7412,9 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.0': {}
 
-  '@docusaurus/types@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
+      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
       '@types/react': 18.3.12
@@ -6928,9 +7434,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -6942,11 +7448,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-validation@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.2.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -6962,11 +7468,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       file-loader: 6.2.0(webpack@5.96.1)
@@ -7000,6 +7506,14 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.1':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      mlly: 1.8.2
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -7073,7 +7587,7 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@mdx-js/mdx@3.1.0(acorn@8.14.0)':
+  '@mdx-js/mdx@3.1.0(acorn@8.16.0)':
     dependencies:
       '@types/estree': 1.0.6
       '@types/estree-jsx': 1.0.5
@@ -7087,7 +7601,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.2
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.14.0)
+      recma-jsx: 1.0.0(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -7109,6 +7623,10 @@ snapshots:
       '@types/react': 18.3.12
       react: 19.2.5
 
+  '@mermaid-js/parser@1.1.0':
+    dependencies:
+      langium: 4.2.3
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7120,6 +7638,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@panzoom/panzoom@4.6.2': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -7286,6 +7806,123 @@ snapshots:
     dependencies:
       '@types/node': 22.9.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
@@ -7326,6 +7963,8 @@ snapshots:
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.9.16
       '@types/serve-static': 1.15.7
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/gtag.js@0.0.20': {}
 
@@ -7438,6 +8077,9 @@ snapshots:
     dependencies:
       '@types/node': 22.9.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -7453,6 +8095,11 @@ snapshots:
       '@types/yargs-parser': 21.0.3
 
   '@ungap/structured-clone@1.2.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@webassemblyjs/ast@1.12.1':
     dependencies:
@@ -7545,11 +8192,17 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.14.0
 
   acorn@8.14.0: {}
+
+  acorn@8.16.0: {}
 
   address@1.2.2: {}
 
@@ -7861,6 +8514,19 @@ snapshots:
       parse5: 7.2.1
       parse5-htmlparser2-tree-adapter: 7.1.0
 
+  chevrotain-allstar@0.4.3(chevrotain@12.0.0):
+    dependencies:
+      chevrotain: 12.0.0
+      lodash-es: 4.18.1
+
+  chevrotain@12.0.0:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 12.0.0
+      '@chevrotain/gast': 12.0.0
+      '@chevrotain/regexp-to-ast': 12.0.0
+      '@chevrotain/types': 12.0.0
+      '@chevrotain/utils': 12.0.0
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -7949,6 +8615,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  confbox@0.1.8: {}
+
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
@@ -8001,6 +8669,14 @@ snapshots:
   core-js@3.39.0: {}
 
   core-util-is@1.0.3: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
@@ -8161,6 +8837,192 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.3
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.3
+
+  cytoscape@3.33.3: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.20: {}
+
   debounce@1.2.1: {}
 
   debug@2.6.9:
@@ -8208,6 +9070,10 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   depd@1.1.2: {}
 
   depd@2.0.0: {}
@@ -8239,9 +9105,9 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  docusaurus-lunr-search@3.6.1(@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  docusaurus-lunr-search@3.6.1(@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.14.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@19.2.5))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       autocomplete.js: 0.37.1
       clsx: 2.1.1
       gauge: 3.0.2
@@ -8284,6 +9150,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.2:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@2.8.0:
     dependencies:
@@ -8685,6 +9555,8 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  hachure-fill@0.5.2: {}
+
   handle-thing@2.0.1: {}
 
   has-flag@4.0.0: {}
@@ -8980,6 +9852,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   icss-utils@5.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -9014,6 +9890,10 @@ snapshots:
   inline-style-parser@0.1.1: {}
 
   inline-style-parser@0.2.4: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
@@ -9180,13 +10060,28 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
+  khroma@2.1.0: {}
+
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  langium@4.2.3:
+    dependencies:
+      '@chevrotain/regexp-to-ast': 12.0.0
+      chevrotain: 12.0.0
+      chevrotain-allstar: 0.4.3(chevrotain@12.0.0)
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
 
   latest-version@7.0.0:
     dependencies:
@@ -9196,6 +10091,10 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.1
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   leven@3.1.0: {}
 
@@ -9214,6 +10113,8 @@ snapshots:
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -9252,6 +10153,8 @@ snapshots:
       repeat-string: 1.6.1
 
   markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
 
   mdast-util-directive@3.0.0:
     dependencies:
@@ -9460,6 +10363,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.14.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.1
+      '@mermaid-js/parser': 1.1.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.3
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.3)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.3)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.2
+      katex: 0.16.45
+      khroma: 2.1.0
+      lodash-es: 4.18.1
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 11.1.1
 
   methods@1.1.2: {}
 
@@ -9811,6 +10738,13 @@ snapshots:
 
   mkdirp@0.3.0: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   mrmime@2.0.0: {}
 
   ms@2.0.0: {}
@@ -9952,6 +10886,8 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.6.3
 
+  package-manager-detector@1.6.0: {}
+
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -9999,6 +10935,8 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
+  path-data-parser@0.1.0: {}
+
   path-exists@5.0.0: {}
 
   path-is-inside@1.0.2: {}
@@ -10017,6 +10955,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -10024,6 +10964,19 @@ snapshots:
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-attribute-case-insensitive@7.0.1(postcss@8.5.6):
     dependencies:
@@ -10619,9 +11572,9 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.0(acorn@8.14.0):
+  recma-jsx@1.0.0(acorn@8.16.0):
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -10802,6 +11755,15 @@ snapshots:
 
   reusify@1.0.4: {}
 
+  robust-predicates@3.0.3: {}
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   rtlcss@4.3.0:
     dependencies:
       escalade: 3.2.0
@@ -10814,6 +11776,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
 
@@ -11094,6 +12058,8 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -11144,6 +12110,8 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinyexec@1.1.2: {}
+
   tinypool@1.1.0: {}
 
   to-regex-range@5.0.1:
@@ -11169,6 +12137,8 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-dedent@2.2.0: {}
+
   tslib@2.8.1: {}
 
   type-fest@0.21.3: {}
@@ -11187,6 +12157,8 @@ snapshots:
       is-typedarray: 1.0.0
 
   typescript@6.0.3: {}
+
+  ufo@1.6.4: {}
 
   undici-types@6.19.8: {}
 
@@ -11323,6 +12295,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@11.1.1: {}
+
   uuid@8.3.2: {}
 
   value-equal@1.0.1: {}
@@ -11357,6 +12331,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.1.0: {}
 
   watchpack@2.4.2:
     dependencies:

--- a/docs/src/components/MermaidPanZoom.tsx
+++ b/docs/src/components/MermaidPanZoom.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef } from "react";
+
+type MermaidPanZoomProps = {
+  id: string;
+  chart: string;
+  className?: string;
+};
+
+type PanzoomInstance = {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  reset: () => void;
+  destroy: () => void;
+  zoomWithWheel: (event: WheelEvent) => void;
+};
+
+export default function MermaidPanZoom({ id, chart, className }: MermaidPanZoomProps): React.JSX.Element {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const pzRef = useRef<PanzoomInstance | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const init = async (): Promise<void> => {
+      const mermaid = (await import("mermaid")).default;
+      const Panzoom = (await import("@panzoom/panzoom")).default;
+
+      if (cancelled || !wrapperRef.current) return;
+
+      const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: "loose",
+        theme: isDark ? "dark" : "default",
+      });
+
+      const { svg } = await mermaid.render(`configarr-mermaid-${id}`, chart);
+      if (cancelled || !wrapperRef.current) return;
+
+      wrapperRef.current.innerHTML = svg;
+      const svgEl = wrapperRef.current.querySelector("svg");
+      if (!svgEl) return;
+
+      svgEl.style.transformOrigin = "0 0";
+
+      pzRef.current?.destroy();
+      pzRef.current = Panzoom(svgEl, {
+        maxScale: 10,
+        minScale: 0.1,
+        startScale: 1,
+        cursor: "grab",
+      });
+
+      wrapperRef.current.addEventListener("wheel", pzRef.current.zoomWithWheel);
+    };
+
+    void init();
+
+    return () => {
+      cancelled = true;
+      if (wrapperRef.current) {
+        wrapperRef.current.removeEventListener("wheel", pzRef.current?.zoomWithWheel as EventListener);
+      }
+      pzRef.current?.destroy();
+      pzRef.current = null;
+    };
+  }, [id, chart]);
+
+  return (
+    <div className={`cf-group-panzoom ${className ?? ""}`.trim()}>
+      <div className="cf-group-panzoom__controls">
+        <button type="button" onClick={() => pzRef.current?.zoomIn()} title="Zoom in">
+          +
+        </button>
+        <button type="button" onClick={() => pzRef.current?.zoomOut()} title="Zoom out">
+          &minus;
+        </button>
+        <button type="button" onClick={() => pzRef.current?.reset()} title="Reset">
+          Reset
+        </button>
+      </div>
+      <div className="cf-group-panzoom__canvas" ref={wrapperRef} />
+    </div>
+  );
+}

--- a/docs/src/components/MermaidPanZoom.tsx
+++ b/docs/src/components/MermaidPanZoom.tsx
@@ -14,12 +14,32 @@ type PanzoomInstance = {
   zoomWithWheel: (event: WheelEvent) => void;
 };
 
+function appendParsedSvg(container: HTMLElement, svgMarkup: string): SVGSVGElement | null {
+  const doc = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
+  if (doc.querySelector("parsererror")) {
+    return null;
+  }
+  const root =
+    doc.documentElement?.tagName.toLowerCase() === "svg"
+      ? doc.documentElement
+      : doc.querySelector("svg");
+  if (!root) {
+    return null;
+  }
+  const svg = document.importNode(root, true) as SVGSVGElement;
+  container.replaceChildren(svg);
+  return svg;
+}
+
 export default function MermaidPanZoom({ id, chart, className }: MermaidPanZoomProps): React.JSX.Element {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const pzRef = useRef<PanzoomInstance | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    const wheelHandler = (event: WheelEvent): void => {
+      pzRef.current?.zoomWithWheel(event);
+    };
 
     const init = async (): Promise<void> => {
       const mermaid = (await import("mermaid")).default;
@@ -38,9 +58,10 @@ export default function MermaidPanZoom({ id, chart, className }: MermaidPanZoomP
       const { svg } = await mermaid.render(`configarr-mermaid-${id}`, chart);
       if (cancelled || !wrapperRef.current) return;
 
-      wrapperRef.current.innerHTML = svg;
-      const svgEl = wrapperRef.current.querySelector("svg");
-      if (!svgEl) return;
+      const svgEl = appendParsedSvg(wrapperRef.current, svg);
+      if (!svgEl) {
+        return;
+      }
 
       svgEl.style.transformOrigin = "0 0";
 
@@ -52,18 +73,20 @@ export default function MermaidPanZoom({ id, chart, className }: MermaidPanZoomP
         cursor: "grab",
       });
 
-      wrapperRef.current.addEventListener("wheel", pzRef.current.zoomWithWheel);
+      wrapperRef.current.addEventListener("wheel", wheelHandler, { passive: false });
     };
 
     void init();
 
     return () => {
       cancelled = true;
-      if (wrapperRef.current) {
-        wrapperRef.current.removeEventListener("wheel", pzRef.current?.zoomWithWheel as EventListener);
+      const host = wrapperRef.current;
+      if (host) {
+        host.removeEventListener("wheel", wheelHandler);
       }
       pzRef.current?.destroy();
       pzRef.current = null;
+      host?.replaceChildren();
     };
   }, [id, chart]);
 

--- a/docs/src/components/MermaidPanZoom.tsx
+++ b/docs/src/components/MermaidPanZoom.tsx
@@ -19,10 +19,7 @@ function appendParsedSvg(container: HTMLElement, svgMarkup: string): SVGSVGEleme
   if (doc.querySelector("parsererror")) {
     return null;
   }
-  const root =
-    doc.documentElement?.tagName.toLowerCase() === "svg"
-      ? doc.documentElement
-      : doc.querySelector("svg");
+  const root = doc.documentElement?.tagName.toLowerCase() === "svg" ? doc.documentElement : doc.querySelector("svg");
   if (!root) {
     return null;
   }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -82,3 +82,46 @@
   font-size: 75%;
   padding: 2px 4px;
 }
+
+.cf-group-panzoom {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin: 1rem 0;
+}
+
+.cf-group-panzoom__controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.cf-group-panzoom__controls button {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-surface-color);
+  border-radius: 6px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.cf-group-panzoom__controls button:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.cf-group-panzoom__canvas {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  width: 100%;
+  height: 180px;
+  background: var(--ifm-background-surface-color);
+  cursor: grab;
+}
+
+.cf-group-panzoom__canvas:active {
+  cursor: grabbing;
+}

--- a/examples/full/config/config.yml
+++ b/examples/full/config/config.yml
@@ -250,6 +250,15 @@ radarr:
         trash_cfgroup_exclude_cfs:
           - id: dc98083864ea246d05a42df0d05f81cc # remove x265 (HD)
 
+    # Experimental defaults for all TRASH profile includes in this instance
+    trash_cfgroup_config:
+      include_optional: true
+      include_unrequired: false
+      include_cfs:
+        - id: dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+      exclude_cfs:
+        - id: 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+
     quality_profiles:
       - name: ExampleInConfigProfile
         reset_unmatched_scores:

--- a/examples/full/config/config.yml
+++ b/examples/full/config/config.yml
@@ -235,8 +235,20 @@ radarr:
       #### Custom
       - template: radarr-cf
       - template: radarr-quality
-      # - template: 2b90e905c99490edc7c7a5787443748b
-      #   source: TRASH
+      # Example: include one TRaSH profile and override auto CF-group behavior for this include only
+      - template: 2b90e905c99490edc7c7a5787443748b # [SQP-1] UHD Remux + WEB (2160p)
+        source: TRASH
+        # include optional default CFs from matched default groups
+        trash_cfgroup_include_optional: true
+        # include all group CFs (required + optional), then refine via include/exclude below
+        trash_cfgroup_include_unrequired: true
+        # allow-list CFs by TRaSH CF trash_id
+        trash_cfgroup_include_cfs:
+          - id: dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+          - id: 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        # deny-list still wins over include list
+        trash_cfgroup_exclude_cfs:
+          - id: dc98083864ea246d05a42df0d05f81cc # remove x265 (HD)
 
     quality_profiles:
       - name: ExampleInConfigProfile

--- a/examples/full/config/config.yml
+++ b/examples/full/config/config.yml
@@ -235,7 +235,7 @@ radarr:
       #### Custom
       - template: radarr-cf
       - template: radarr-quality
-      # Example: include one TRaSH profile and override auto CF-group behavior for this include only
+      # Example: include one TRaSH profile and override auto CF-group behavior for this include only (trash_cfgroup_* since v1.28.0)
       - template: 2b90e905c99490edc7c7a5787443748b # [SQP-1] UHD Remux + WEB (2160p)
         source: TRASH
         # include optional default CFs from matched default groups
@@ -250,7 +250,7 @@ radarr:
         trash_cfgroup_exclude_cfs:
           - id: dc98083864ea246d05a42df0d05f81cc # remove x265 (HD)
 
-    # Experimental defaults for all TRASH profile includes in this instance
+    # Experimental defaults for all TRaSH profile includes in this instance (since v1.28.0)
     trash_cfgroup_config:
       include_optional: true
       include_unrequired: false

--- a/examples/full/config/config.yml
+++ b/examples/full/config/config.yml
@@ -242,7 +242,7 @@ radarr:
         trash_cfgroup_include_optional: true
         # include all group CFs (required + optional), then refine via include/exclude below
         trash_cfgroup_include_unrequired: true
-        # allow-list CFs by TRaSH CF trash_id
+        # add CFs by TRaSH CF trash_id (additive, does not replace base selection)
         trash_cfgroup_include_cfs:
           - id: dc98083864ea246d05a42df0d05f81cc # x265 (HD)
           - id: 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -470,7 +470,7 @@ describe("mergeConfigsAndTemplates", () => {
 
     const disabledInput: InputConfigArrInstance = {
       ...enabledInput,
-      trash_cfgroup_include_optional: false,
+      trash_cfgroup_config: { include_optional: false },
     };
 
     const enabledResult = await mergeConfigsAndTemplates({}, enabledInput, "SONARR");

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -543,7 +543,7 @@ describe("mergeConfigsAndTemplates", () => {
     const ids = result.config.custom_formats.flatMap((cf) => cf.trash_ids || []);
     expect(ids).toContain("cf-optional");
     expect(ids).not.toContain("cf-required");
-    expect(ids).not.toContain("cf-optional-default");
+    expect(ids).toContain("cf-optional-default");
   });
 
   test("should auto-detect QD JSON from TRASH URL and apply it to quality_definition", async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./types/config.types";
 import { TrashQP, TrashQualityDefinition } from "./types/trashguide.types";
 import { cloneWithJSON } from "./util";
+import { logger } from "./logger";
 
 // Mock ky for URL template tests
 const mockKyGet = vi.hoisted(() => vi.fn());
@@ -422,6 +423,68 @@ describe("mergeConfigsAndTemplates", () => {
     expect(result.config.quality_profiles[0]!.name).toBe("TRASH Profile");
   });
 
+  test("should allow disabling auto-load of default optional CFs per instance", async () => {
+    const trashTemplate: TrashQP = {
+      trash_id: "test-trash-id",
+      name: "TRASH Profile",
+      trash_score_set: "default",
+      upgradeAllowed: true,
+      cutoff: "HDTV-1080p",
+      minFormatScore: 0,
+      cutoffFormatScore: 1000,
+      items: [{ name: "HDTV-1080p", allowed: true }],
+      formatItems: {},
+    };
+
+    const groupRequired = { name: "cf-required", trash_id: "cf-required", required: true };
+    const groupOptionalDefault = { name: "cf-optional-default", trash_id: "cf-optional-default", required: false, default: true };
+
+    vi.spyOn(reclarrImporter, "loadRecyclarrTemplates").mockReturnValue(new Map());
+    vi.spyOn(localImporter, "loadLocalRecyclarrTemplate").mockReturnValue(new Map());
+    vi.spyOn(trashGuide, "loadQPFromTrash").mockReturnValue(Promise.resolve(new Map([["trash-template", trashTemplate]])));
+    vi.spyOn(trashGuide, "loadAllQDsFromTrash").mockReturnValue(Promise.resolve(new Map()));
+    vi.spyOn(trashGuide, "loadTrashCustomFormatGroups").mockReturnValue(
+      Promise.resolve(
+        new Map([
+          [
+            "group1",
+            {
+              name: "group1",
+              trash_id: "group1",
+              default: "true",
+              custom_formats: [groupRequired, groupOptionalDefault],
+              quality_profiles: { include: { "TRASH Profile": "test-trash-id" } },
+            },
+          ],
+        ]),
+      ),
+    );
+
+    const enabledInput: InputConfigArrInstance = {
+      include: [{ template: "trash-template", source: "TRASH" }],
+      custom_formats: [],
+      quality_profiles: [],
+      api_key: "test",
+      base_url: "http://sonarr:8989",
+    };
+
+    const disabledInput: InputConfigArrInstance = {
+      ...enabledInput,
+      includeDefaultOptionalTrashGroupCfs: false,
+    };
+
+    const enabledResult = await mergeConfigsAndTemplates({}, enabledInput, "SONARR");
+    const disabledResult = await mergeConfigsAndTemplates({}, disabledInput, "SONARR");
+
+    const enabledIds = enabledResult.config.custom_formats.flatMap((cf) => cf.trash_ids || []);
+    const disabledIds = disabledResult.config.custom_formats.flatMap((cf) => cf.trash_ids || []);
+
+    expect(enabledIds).toContain("cf-required");
+    expect(enabledIds).toContain("cf-optional-default");
+    expect(disabledIds).toContain("cf-required");
+    expect(disabledIds).not.toContain("cf-optional-default");
+  });
+
   test("should auto-detect QD JSON from TRASH URL and apply it to quality_definition", async () => {
     const qdTemplate: TrashQualityDefinition = {
       trash_id: "aed34b9f60ee115dfa7918b742336277",
@@ -622,6 +685,44 @@ describe("custom_formats ordering", () => {
     const result = await mergeConfigsAndTemplates({}, inputConfig, "SONARR");
     const ids = result.config.custom_formats.map((cf) => cf.trash_ids?.[0]).filter(Boolean);
     expect(ids).toEqual(["cf-group"]);
+  });
+
+  test("should propagate silenceRequiredCfGroupExclusionWarnings to include and instance custom_format_groups", async () => {
+    const loggerWarnSpy = vi.spyOn(logger, "warn");
+
+    const groupCFRequired = { name: "cf-group-required", trash_id: "cf-group-required", required: true };
+    const templateWithGroup: MappedTemplates = {
+      custom_format_groups: [
+        {
+          trash_guide: [{ id: "group1", exclude: [{ id: "cf-group-required" }] }],
+          assign_scores_to: [{ name: "profile" }],
+        },
+      ],
+    };
+
+    const recyclarrTemplates: Map<string, MappedTemplates> = new Map([["template1", templateWithGroup]]);
+    vi.spyOn(reclarrImporter, "loadRecyclarrTemplates").mockReturnValue(recyclarrTemplates);
+    vi.spyOn(localImporter, "loadLocalRecyclarrTemplate").mockReturnValue(new Map());
+    vi.spyOn(trashGuide, "loadQPFromTrash").mockReturnValue(Promise.resolve(new Map()));
+    vi.spyOn(trashGuide, "loadTrashCustomFormatGroups").mockReturnValue(
+      Promise.resolve(new Map([["group1", { name: "group1", trash_id: "group1", custom_formats: [groupCFRequired] }]])),
+    );
+
+    const inputConfig: InputConfigArrInstance = {
+      include: [{ template: "template1", source: "RECYCLARR" }],
+      custom_format_groups: [
+        { trash_guide: [{ id: "group1", exclude: [{ id: "cf-group-required" }] }], assign_scores_to: [{ name: "profile" }] },
+      ],
+      custom_formats: [],
+      quality_profiles: [dummyProfile],
+      api_key: "test",
+      base_url: "http://sonarr:8989",
+    };
+
+    await mergeConfigsAndTemplates({ silenceRequiredCfGroupExclusionWarnings: true }, inputConfig, "SONARR");
+
+    const requiredExclusionWarnCalls = loggerWarnSpy.mock.calls.filter((call) => String(call[0]).includes("exclude removes required CF"));
+    expect(requiredExclusionWarnCalls).toHaveLength(0);
   });
 
   test("should overwrite custom format scores in correct order (in template overwrite, group)", async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -470,7 +470,7 @@ describe("mergeConfigsAndTemplates", () => {
 
     const disabledInput: InputConfigArrInstance = {
       ...enabledInput,
-      includeDefaultOptionalTrashGroupCfs: false,
+      trash_cfgroup_include_optional: false,
     };
 
     const enabledResult = await mergeConfigsAndTemplates({}, enabledInput, "SONARR");
@@ -483,6 +483,67 @@ describe("mergeConfigsAndTemplates", () => {
     expect(enabledIds).toContain("cf-optional-default");
     expect(disabledIds).toContain("cf-required");
     expect(disabledIds).not.toContain("cf-optional-default");
+  });
+
+  test("should apply include-level TRASH CF-group overrides", async () => {
+    const trashTemplate: TrashQP = {
+      trash_id: "test-trash-id",
+      name: "TRASH Profile",
+      trash_score_set: "default",
+      upgradeAllowed: true,
+      cutoff: "HDTV-1080p",
+      minFormatScore: 0,
+      cutoffFormatScore: 1000,
+      items: [{ name: "HDTV-1080p", allowed: true }],
+      formatItems: {},
+    };
+
+    const groupRequired = { name: "cf-required", trash_id: "cf-required", required: true };
+    const groupOptionalDefault = { name: "cf-optional-default", trash_id: "cf-optional-default", required: false, default: true };
+    const groupOptional = { name: "cf-optional", trash_id: "cf-optional", required: false };
+
+    vi.spyOn(reclarrImporter, "loadRecyclarrTemplates").mockReturnValue(new Map());
+    vi.spyOn(localImporter, "loadLocalRecyclarrTemplate").mockReturnValue(new Map());
+    vi.spyOn(trashGuide, "loadQPFromTrash").mockReturnValue(Promise.resolve(new Map([["trash-template", trashTemplate]])));
+    vi.spyOn(trashGuide, "loadAllQDsFromTrash").mockReturnValue(Promise.resolve(new Map()));
+    vi.spyOn(trashGuide, "loadTrashCustomFormatGroups").mockReturnValue(
+      Promise.resolve(
+        new Map([
+          [
+            "group1",
+            {
+              name: "group1",
+              trash_id: "group1",
+              default: "true",
+              custom_formats: [groupRequired, groupOptionalDefault, groupOptional],
+              quality_profiles: { include: { "TRASH Profile": "test-trash-id" } },
+            },
+          ],
+        ]),
+      ),
+    );
+
+    const inputConfig: InputConfigArrInstance = {
+      include: [
+        {
+          template: "trash-template",
+          source: "TRASH",
+          trash_cfgroup_include_unrequired: true,
+          trash_cfgroup_include_cfs: [{ id: "cf-required" }, { id: "cf-optional" }],
+          trash_cfgroup_exclude_cfs: [{ id: "cf-required" }],
+        },
+      ],
+      custom_formats: [],
+      quality_profiles: [],
+      api_key: "test",
+      base_url: "http://sonarr:8989",
+    };
+
+    const result = await mergeConfigsAndTemplates({}, inputConfig, "SONARR");
+    const ids = result.config.custom_formats.flatMap((cf) => cf.trash_ids || []);
+    expect(ids).toContain("cf-optional");
+    expect(ids).not.toContain("cf-required");
+    expect(ids).not.toContain("cf-optional-default");
   });
 
   test("should auto-detect QD JSON from TRASH URL and apply it to quality_definition", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -748,10 +748,10 @@ export const mergeConfigsAndTemplates = async (
   // When false/undefined: use new "include" semantics (apply only to included)
   const useExcludeSemantics = globalConfig.compatibilityTrashGuide20260219Enabled === true;
   const autoTrashCfGroupDefaults: TransformTrashQPCFGroupsOptions = {
-    includeDefaultOptionalCfs: instanceConfig.trash_cfgroup_include_optional ?? instanceConfig.includeDefaultOptionalTrashGroupCfs ?? true,
-    includeUnrequired: instanceConfig.trash_cfgroup_include_unrequired ?? false,
-    includeCfs: instanceConfig.trash_cfgroup_include_cfs,
-    excludeCfs: instanceConfig.trash_cfgroup_exclude_cfs,
+    includeDefaultOptionalCfs: instanceConfig.trash_cfgroup_config?.include_optional ?? true,
+    includeUnrequired: instanceConfig.trash_cfgroup_config?.include_unrequired ?? false,
+    includeCfs: instanceConfig.trash_cfgroup_config?.include_cfs,
+    excludeCfs: instanceConfig.trash_cfgroup_config?.exclude_cfs,
     silenceRequiredExclusionWarnings: globalConfig.silenceRequiredCfGroupExclusionWarnings === true,
   };
   const cfGroupOptions: TransformTrashCFGroupsOptions = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ import {
   loadQPFromTrash,
   loadTrashCustomFormatGroups,
   transformTrashCFGroups,
+  TransformTrashCFGroupsOptions,
   transformTrashQDs,
   transformTrashQPCFGroups,
   transformTrashQPCFs,
@@ -322,9 +323,10 @@ const expandAndAppendCustomFormatGroups = (
   customFormatGroups: InputConfigCustomFormatGroup[] | undefined,
   trashCFGroupMapping: TrashCFGroupMapping,
   mergedTemplates: MappedMergedTemplates,
+  cfGroupOptions?: TransformTrashCFGroupsOptions,
 ) => {
   if (!customFormatGroups || customFormatGroups.length === 0) return;
-  const expanded = transformTrashCFGroups(trashCFGroupMapping, customFormatGroups);
+  const expanded = transformTrashCFGroups(trashCFGroupMapping, customFormatGroups, cfGroupOptions);
   if (expanded.length > 0) {
     logger.debug(`Expanded and appended ${expanded.length} custom formats from customFormatGroups`);
     mergedTemplates.custom_formats.push(...expanded);
@@ -336,14 +338,16 @@ const includeRecyclarrTemplate = (
   {
     mergedTemplates,
     trashCFGroupMapping,
+    cfGroupOptions,
   }: {
     mergedTemplates: MappedMergedTemplates;
     trashCFGroupMapping: TrashCFGroupMapping;
+    cfGroupOptions?: TransformTrashCFGroupsOptions;
   },
 ) => {
   // First expand and append group custom formats
   if (template.custom_format_groups) {
-    expandAndAppendCustomFormatGroups(template.custom_format_groups, trashCFGroupMapping, mergedTemplates);
+    expandAndAppendCustomFormatGroups(template.custom_format_groups, trashCFGroupMapping, mergedTemplates, cfGroupOptions);
   }
   // Then push direct custom formats after, so they always win
   if (template.custom_formats) {
@@ -418,11 +422,13 @@ const includeTrashTemplate = (
     trashCFGroupMapping,
     customFormatGroups,
     useExcludeSemantics,
+    includeDefaultOptionalTrashGroupCfs,
   }: {
     mergedTemplates: MappedMergedTemplates;
     trashCFGroupMapping: TrashCFGroupMapping;
     customFormatGroups: InputConfigCustomFormatGroup[];
     useExcludeSemantics: boolean;
+    includeDefaultOptionalTrashGroupCfs: boolean;
   },
 ) => {
   // useExcludeSemantics=true means use old TRaSH-Guides behavior (before Feb 2026)
@@ -431,7 +437,12 @@ const includeTrashTemplate = (
   mergedTemplates.custom_formats.push(transformTrashQPCFs(template));
 
   // For TrashGuide profiles, check and include default CF groups
-  const requiredCFsFromCFGroups = transformTrashQPCFGroups(template, trashCFGroupMapping, useExcludeSemantics);
+  const requiredCFsFromCFGroups = transformTrashQPCFGroups(
+    template,
+    trashCFGroupMapping,
+    useExcludeSemantics,
+    includeDefaultOptionalTrashGroupCfs,
+  );
 
   const numberOfCfsLoaded = requiredCFsFromCFGroups.reduce((p, c) => {
     (c.trash_ids || []).forEach((id) => p.add(id));
@@ -488,6 +499,8 @@ const includeTemplateOrderDefault = async (
     trashQD,
     trashCFGroupMapping,
     useExcludeSemantics,
+    cfGroupOptions,
+    includeDefaultOptionalTrashGroupCfs,
   }: {
     recyclarr: Map<string, MappedTemplates>;
     local: Map<string, MappedTemplates>;
@@ -495,6 +508,8 @@ const includeTemplateOrderDefault = async (
     trashQD: Map<string, TrashQualityDefinition>;
     trashCFGroupMapping: TrashCFGroupMapping;
     useExcludeSemantics: boolean;
+    cfGroupOptions?: TransformTrashCFGroupsOptions;
+    includeDefaultOptionalTrashGroupCfs: boolean;
   },
   { mergedTemplates }: { mergedTemplates: MappedMergedTemplates },
 ) => {
@@ -582,10 +597,11 @@ const includeTemplateOrderDefault = async (
           trashCFGroupMapping,
           customFormatGroups: [],
           useExcludeSemantics,
+          includeDefaultOptionalTrashGroupCfs,
         });
       }
     } else {
-      includeRecyclarrTemplate(resolvedTemplate as MappedTemplates, { mergedTemplates, trashCFGroupMapping });
+      includeRecyclarrTemplate(resolvedTemplate as MappedTemplates, { mergedTemplates, trashCFGroupMapping, cfGroupOptions });
     }
   }
 
@@ -607,6 +623,7 @@ const includeTemplateOrderDefault = async (
       trashCFGroupMapping,
       customFormatGroups: [],
       useExcludeSemantics,
+      includeDefaultOptionalTrashGroupCfs,
     });
   });
   mappedIncludes.recyclarr.forEach((e) => {
@@ -615,7 +632,7 @@ const includeTemplateOrderDefault = async (
       logger.warn(`Unknown 'recyclarr' template requested: '${e.template}'`);
       return;
     }
-    includeRecyclarrTemplate(resolvedTemplate, { mergedTemplates, trashCFGroupMapping });
+    includeRecyclarrTemplate(resolvedTemplate, { mergedTemplates, trashCFGroupMapping, cfGroupOptions });
   });
   mappedIncludes.local.forEach((e) => {
     const resolvedTemplate = local.get(e.template);
@@ -623,7 +640,7 @@ const includeTemplateOrderDefault = async (
       logger.warn(`Unknown 'local' template requested: '${e.template}'`);
       return;
     }
-    includeRecyclarrTemplate(resolvedTemplate, { mergedTemplates, trashCFGroupMapping });
+    includeRecyclarrTemplate(resolvedTemplate, { mergedTemplates, trashCFGroupMapping, cfGroupOptions });
   });
 };
 
@@ -725,6 +742,10 @@ export const mergeConfigsAndTemplates = async (
   // When true: use old "exclude" semantics (apply to all except excluded)
   // When false/undefined: use new "include" semantics (apply only to included)
   const useExcludeSemantics = globalConfig.compatibilityTrashGuide20260219Enabled === true;
+  const includeDefaultOptionalTrashGroupCfs = instanceConfig.includeDefaultOptionalTrashGroupCfs !== false;
+  const cfGroupOptions: TransformTrashCFGroupsOptions = {
+    silenceRequiredCfGroupExclusionWarnings: globalConfig.silenceRequiredCfGroupExclusionWarnings === true,
+  };
   if (instanceConfig.include) {
     await includeTemplateOrderDefault(
       instanceConfig.include,
@@ -735,6 +756,8 @@ export const mergeConfigsAndTemplates = async (
         trashQD: trashQDTemplates,
         trashCFGroupMapping,
         useExcludeSemantics,
+        cfGroupOptions,
+        includeDefaultOptionalTrashGroupCfs,
       },
       {
         mergedTemplates,
@@ -744,7 +767,7 @@ export const mergeConfigsAndTemplates = async (
 
   // Now handle instanceConfig custom_format_groups before direct custom_formats
   if (instanceConfig.custom_format_groups) {
-    expandAndAppendCustomFormatGroups(instanceConfig.custom_format_groups, trashCFGroupMapping, mergedTemplates);
+    expandAndAppendCustomFormatGroups(instanceConfig.custom_format_groups, trashCFGroupMapping, mergedTemplates, cfGroupOptions);
   }
   if (instanceConfig.custom_formats) {
     mergedTemplates.custom_formats.push(...instanceConfig.custom_formats);

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ import {
   loadTrashCustomFormatGroups,
   transformTrashCFGroups,
   TransformTrashCFGroupsOptions,
+  TransformTrashQPCFGroupsOptions,
   transformTrashQDs,
   transformTrashQPCFGroups,
   transformTrashQPCFs,
@@ -267,6 +268,11 @@ export const transformConfig = (input: InputConfigSchema): ConfigSchema => {
 export const parseIncludes = (input: InputConfigIncludeItem): ConfigIncludeItem => ({
   template: input.template,
   source: input.source ?? "RECYCLARR",
+  preferred_ratio: input.preferred_ratio,
+  trash_cfgroup_include_optional: input.trash_cfgroup_include_optional,
+  trash_cfgroup_include_unrequired: input.trash_cfgroup_include_unrequired,
+  trash_cfgroup_include_cfs: input.trash_cfgroup_include_cfs,
+  trash_cfgroup_exclude_cfs: input.trash_cfgroup_exclude_cfs,
 });
 
 /**
@@ -420,15 +426,13 @@ const includeTrashTemplate = (
   {
     mergedTemplates,
     trashCFGroupMapping,
-    customFormatGroups,
     useExcludeSemantics,
-    includeDefaultOptionalTrashGroupCfs,
+    autoTrashCfGroupOptions,
   }: {
     mergedTemplates: MappedMergedTemplates;
     trashCFGroupMapping: TrashCFGroupMapping;
-    customFormatGroups: InputConfigCustomFormatGroup[];
     useExcludeSemantics: boolean;
-    includeDefaultOptionalTrashGroupCfs: boolean;
+    autoTrashCfGroupOptions: TransformTrashQPCFGroupsOptions;
   },
 ) => {
   // useExcludeSemantics=true means use old TRaSH-Guides behavior (before Feb 2026)
@@ -437,12 +441,7 @@ const includeTrashTemplate = (
   mergedTemplates.custom_formats.push(transformTrashQPCFs(template));
 
   // For TrashGuide profiles, check and include default CF groups
-  const requiredCFsFromCFGroups = transformTrashQPCFGroups(
-    template,
-    trashCFGroupMapping,
-    useExcludeSemantics,
-    includeDefaultOptionalTrashGroupCfs,
-  );
+  const requiredCFsFromCFGroups = transformTrashQPCFGroups(template, trashCFGroupMapping, useExcludeSemantics, autoTrashCfGroupOptions);
 
   const numberOfCfsLoaded = requiredCFsFromCFGroups.reduce((p, c) => {
     (c.trash_ids || []).forEach((id) => p.add(id));
@@ -500,7 +499,7 @@ const includeTemplateOrderDefault = async (
     trashCFGroupMapping,
     useExcludeSemantics,
     cfGroupOptions,
-    includeDefaultOptionalTrashGroupCfs,
+    autoTrashCfGroupDefaults,
   }: {
     recyclarr: Map<string, MappedTemplates>;
     local: Map<string, MappedTemplates>;
@@ -509,10 +508,18 @@ const includeTemplateOrderDefault = async (
     trashCFGroupMapping: TrashCFGroupMapping;
     useExcludeSemantics: boolean;
     cfGroupOptions?: TransformTrashCFGroupsOptions;
-    includeDefaultOptionalTrashGroupCfs: boolean;
+    autoTrashCfGroupDefaults: TransformTrashQPCFGroupsOptions;
   },
   { mergedTemplates }: { mergedTemplates: MappedMergedTemplates },
 ) => {
+  const resolveAutoTrashCfGroupOptions = (includeItem: InputConfigIncludeItem): TransformTrashQPCFGroupsOptions => ({
+    includeDefaultOptionalCfs: includeItem.trash_cfgroup_include_optional ?? autoTrashCfGroupDefaults.includeDefaultOptionalCfs ?? true,
+    includeUnrequired: includeItem.trash_cfgroup_include_unrequired ?? autoTrashCfGroupDefaults.includeUnrequired ?? false,
+    includeCfs: includeItem.trash_cfgroup_include_cfs ?? autoTrashCfGroupDefaults.includeCfs,
+    excludeCfs: includeItem.trash_cfgroup_exclude_cfs ?? autoTrashCfGroupDefaults.excludeCfs,
+    silenceRequiredExclusionWarnings: autoTrashCfGroupDefaults.silenceRequiredExclusionWarnings,
+  });
+
   const mappedIncludes = include.reduce<{
     local: InputConfigIncludeItem[];
     recyclarr: InputConfigIncludeItem[];
@@ -595,9 +602,8 @@ const includeTemplateOrderDefault = async (
         includeTrashTemplate(resolvedTemplate as TrashQP, {
           mergedTemplates,
           trashCFGroupMapping,
-          customFormatGroups: [],
           useExcludeSemantics,
-          includeDefaultOptionalTrashGroupCfs,
+          autoTrashCfGroupOptions: resolveAutoTrashCfGroupOptions(e),
         });
       }
     } else {
@@ -621,9 +627,8 @@ const includeTemplateOrderDefault = async (
     includeTrashTemplate(resolvedTemplate, {
       mergedTemplates,
       trashCFGroupMapping,
-      customFormatGroups: [],
       useExcludeSemantics,
-      includeDefaultOptionalTrashGroupCfs,
+      autoTrashCfGroupOptions: resolveAutoTrashCfGroupOptions(e),
     });
   });
   mappedIncludes.recyclarr.forEach((e) => {
@@ -742,7 +747,13 @@ export const mergeConfigsAndTemplates = async (
   // When true: use old "exclude" semantics (apply to all except excluded)
   // When false/undefined: use new "include" semantics (apply only to included)
   const useExcludeSemantics = globalConfig.compatibilityTrashGuide20260219Enabled === true;
-  const includeDefaultOptionalTrashGroupCfs = instanceConfig.includeDefaultOptionalTrashGroupCfs !== false;
+  const autoTrashCfGroupDefaults: TransformTrashQPCFGroupsOptions = {
+    includeDefaultOptionalCfs: instanceConfig.trash_cfgroup_include_optional ?? instanceConfig.includeDefaultOptionalTrashGroupCfs ?? true,
+    includeUnrequired: instanceConfig.trash_cfgroup_include_unrequired ?? false,
+    includeCfs: instanceConfig.trash_cfgroup_include_cfs,
+    excludeCfs: instanceConfig.trash_cfgroup_exclude_cfs,
+    silenceRequiredExclusionWarnings: globalConfig.silenceRequiredCfGroupExclusionWarnings === true,
+  };
   const cfGroupOptions: TransformTrashCFGroupsOptions = {
     silenceRequiredCfGroupExclusionWarnings: globalConfig.silenceRequiredCfGroupExclusionWarnings === true,
   };
@@ -757,7 +768,7 @@ export const mergeConfigsAndTemplates = async (
         trashCFGroupMapping,
         useExcludeSemantics,
         cfGroupOptions,
-        includeDefaultOptionalTrashGroupCfs,
+        autoTrashCfGroupDefaults,
       },
       {
         mergedTemplates,

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -638,7 +638,7 @@ describe("TrashGuide", async () => {
         },
       });
 
-      const result = transformTrashQPCFGroups(mockTrashQP, mapping, false, false);
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping, false, { includeDefaultOptionalCfs: false });
 
       expect(result).toHaveLength(1);
       expect(result[0]?.trash_ids).toEqual(["cf1"]);

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -11,6 +11,7 @@ import {
 import { InputConfigCustomFormatGroup } from "./types/config.types";
 import { TrashCFGroupMapping, TrashQualityDefinition, TrashQP } from "./types/trashguide.types";
 import * as util from "./util";
+import { logger } from "./logger";
 
 describe("TrashGuide", async () => {
   beforeEach(() => {
@@ -256,6 +257,233 @@ describe("TrashGuide", async () => {
     expect(result[0]!.assign_scores_to![0]?.score).toBe(0);
   });
 
+  test("transformTrashCFGroups - includes optional CF when default is true (TRaSH semantics)", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: true },
+        { name: "cf2", trash_id: "cf2", required: false, default: true },
+        { name: "cf3", trash_id: "cf3", required: false },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1" }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf1", "cf2"]);
+  });
+
+  test("transformTrashCFGroups - optional CF default may be string true", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: false, default: "true" },
+        { name: "cf2", trash_id: "cf2", required: false },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1" }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf1"]);
+  });
+
+  test("transformTrashCFGroups - include allow-list only picks listed ids", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: true },
+        { name: "cf2", trash_id: "cf2", required: false, default: true },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", include: [{ id: "cf2" }] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf2"]);
+  });
+
+  test("transformTrashCFGroups - exclude wins over include for same id", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: false, default: true },
+        { name: "cf2", trash_id: "cf2", required: true },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", include: [{ id: "cf1" }, { id: "cf2" }], exclude: [{ id: "cf2" }] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf1"]);
+  });
+
+  test("transformTrashCFGroups - warns when excluding required CF", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: true },
+        { name: "cf2", trash_id: "cf2", required: false, default: true },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", exclude: [{ id: "cf1" }] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf2"]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("exclude removes required CF"));
+  });
+
+  test("transformTrashCFGroups - silence flag suppresses required-exclusion warn", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+    const debugSpy = vi.spyOn(logger, "debug");
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", exclude: [{ id: "cf1" }] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups, { silenceRequiredCfGroupExclusionWarnings: true });
+    expect(result).toHaveLength(0);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("exclude removes required CF"))).toBe(false);
+    expect(debugSpy.mock.calls.some((c) => String(c[0]).includes("(silenced)"))).toBe(true);
+  });
+
+  test("transformTrashCFGroups - include with unknown id logs warn and skips id", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", include: [{ id: "cf1" }, { id: "nope" }] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf1"]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("include references unknown CF trash_id"));
+  });
+
+  test("transformTrashCFGroups - include empty list yields no CFs", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [{ name: "cf1", trash_id: "cf1", required: true }],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", include: [] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result).toHaveLength(0);
+  });
+
+  test("transformTrashCFGroups - include_unrequired plus exclude keeps exclude precedence", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: true },
+        { name: "cf2", trash_id: "cf2", required: false },
+        { name: "cf3", trash_id: "cf3", required: false },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [{ id: "id1", include_unrequired: true, exclude: [{ id: "cf2" }] }],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf1", "cf3"]);
+  });
+
+  test("transformTrashCFGroups - duplicate ids in include/exclude are deduped", async () => {
+    const mapping: TrashCFGroupMapping = new Map();
+    mapping.set("id1", {
+      name: "name1",
+      trash_id: "id1",
+      custom_formats: [
+        { name: "cf1", trash_id: "cf1", required: true },
+        { name: "cf2", trash_id: "cf2", required: false, default: true },
+      ],
+    });
+
+    const groups: InputConfigCustomFormatGroup[] = [
+      {
+        trash_guide: [
+          {
+            id: "id1",
+            include: [{ id: "cf1" }, { id: "cf1" }, { id: "cf2" }],
+            exclude: [{ id: "cf2" }, { id: "cf2" }],
+          },
+        ],
+        assign_scores_to: [{ name: "qp1" }],
+      },
+    ];
+
+    const result = transformTrashCFGroups(mapping, groups);
+    expect(result[0]!.trash_ids).toEqual(["cf1"]);
+  });
+
   describe("transformTrashQPCFGroups - new include semantics (default)", () => {
     const mockTrashQP: TrashQP = {
       trash_id: "profile123",
@@ -391,6 +619,29 @@ describe("TrashGuide", async () => {
       expect(result).toHaveLength(1);
       expect(result[0]?.trash_ids).toEqual(["cf1", "cf2"]);
       expect(result[0]?.assign_scores_to).toEqual([{ name: "Test Profile" }]);
+    });
+
+    test("should include only required CFs when optional default CF loading is disabled", () => {
+      const mapping: TrashCFGroupMapping = new Map();
+      mapping.set("group1", {
+        name: "Default Group 1",
+        trash_id: "group1",
+        default: "true",
+        custom_formats: [
+          { name: "cf1", trash_id: "cf1", required: true },
+          { name: "cf2", trash_id: "cf2", required: false, default: true },
+        ],
+        quality_profiles: {
+          include: {
+            "Test Profile": "profile123",
+          },
+        },
+      });
+
+      const result = transformTrashQPCFGroups(mockTrashQP, mapping, false, false);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.trash_ids).toEqual(["cf1"]);
     });
 
     test("should skip groups without default=true even if in include list", () => {

--- a/src/trash-guide.test.ts
+++ b/src/trash-guide.test.ts
@@ -302,7 +302,7 @@ describe("TrashGuide", async () => {
     expect(result[0]!.trash_ids).toEqual(["cf1"]);
   });
 
-  test("transformTrashCFGroups - include allow-list only picks listed ids", async () => {
+  test("transformTrashCFGroups - include adds to base selection (does not replace)", async () => {
     const mapping: TrashCFGroupMapping = new Map();
     mapping.set("id1", {
       name: "name1",
@@ -321,7 +321,7 @@ describe("TrashGuide", async () => {
     ];
 
     const result = transformTrashCFGroups(mapping, groups);
-    expect(result[0]!.trash_ids).toEqual(["cf2"]);
+    expect(result[0]!.trash_ids).toEqual(["cf1", "cf2"]);
   });
 
   test("transformTrashCFGroups - exclude wins over include for same id", async () => {
@@ -414,7 +414,7 @@ describe("TrashGuide", async () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("include references unknown CF trash_id"));
   });
 
-  test("transformTrashCFGroups - include empty list yields no CFs", async () => {
+  test("transformTrashCFGroups - include empty list keeps base selection", async () => {
     const mapping: TrashCFGroupMapping = new Map();
     mapping.set("id1", {
       name: "name1",
@@ -430,7 +430,7 @@ describe("TrashGuide", async () => {
     ];
 
     const result = transformTrashCFGroups(mapping, groups);
-    expect(result).toHaveLength(0);
+    expect(result[0]!.trash_ids).toEqual(["cf1"]);
   });
 
   test("transformTrashCFGroups - include_unrequired plus exclude keeps exclude precedence", async () => {

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -6,13 +6,20 @@ import { getConfig } from "./config";
 import { logger } from "./logger";
 import { interpolateSize } from "./quality-definitions";
 import { CFIDToConfigGroup, ConfigarrCF, QualityDefinitionsRadarr, QualityDefinitionsSonarr } from "./types/common.types";
-import { ConfigCustomFormat, ConfigQualityProfile, ConfigQualityProfileItem, InputConfigCustomFormatGroup } from "./types/config.types";
+import {
+  ConfigCustomFormat,
+  ConfigQualityProfile,
+  ConfigQualityProfileItem,
+  InputConfigCfGroupTrashGuideItem,
+  InputConfigCustomFormatGroup,
+} from "./types/config.types";
 import {
   TrashArrSupported,
   TrashCache,
   TrashCF,
   TrashCFConflict,
   TrashCFGroupMapping,
+  TrashCFGItem,
   TrashCustomFormatGroups,
   TrashQP,
   TrashQualityDefinition,
@@ -468,25 +475,91 @@ export const transformTrashQPCFs = (data: TrashQP): ConfigCustomFormat => {
   return { assign_scores_to: [{ name: data.name }], trash_ids: Object.values(data.formatItems) };
 };
 
+const isCfDefaultSelected = (cf: Pick<TrashCFGItem, "default">): boolean => {
+  return cf.default === true || cf.default === "true";
+};
+
+const isTrashGroupDefaultEnabled = (cfGroup: Pick<TrashCustomFormatGroups, "default">): boolean => {
+  return cfGroup.default === true || cfGroup.default === "true";
+};
+
+const cfIncludedInExplicitGroupExpansion = (cf: TrashCFGItem, includeUnrequired: boolean): boolean => {
+  if (includeUnrequired) {
+    return true;
+  }
+  return cf.required === true || isCfDefaultSelected(cf);
+};
+
+const dedupeIds = (ids: string[]): string[] => [...new Set(ids)];
+
+function selectCustomFormatsForGroupExpansion(
+  mapping: TrashCustomFormatGroups,
+  guideItem: InputConfigCfGroupTrashGuideItem,
+  silenceRequiredExclusionWarnings: boolean,
+): string[] {
+  const cfById = new Map(mapping.custom_formats.map((cf) => [cf.trash_id, cf]));
+  const includeUnrequired = guideItem.include_unrequired === true;
+
+  const excludeIds = dedupeIds(guideItem.exclude?.map((e) => e.id) ?? []);
+
+  for (const id of excludeIds) {
+    const cf = cfById.get(id);
+    if (cf?.required === true) {
+      if (!silenceRequiredExclusionWarnings) {
+        logger.warn(`Custom format group '${mapping.name}' (${mapping.trash_id}): exclude removes required CF '${cf.name}' (${id}).`);
+      } else {
+        logger.debug(
+          `Custom format group '${mapping.name}' (${mapping.trash_id}): exclude removes required CF '${cf.name}' (${id}) (silenced).`,
+        );
+      }
+    } else if (!cf) {
+      logger.debug(`Custom format group '${mapping.name}' (${mapping.trash_id}): exclude lists unknown CF trash_id '${id}'.`);
+    }
+  }
+
+  const includeIds = dedupeIds(guideItem.include?.map((e) => e.id) ?? []);
+
+  let selectedIds: string[];
+
+  if (guideItem.include !== undefined) {
+    selectedIds = [];
+    for (const id of includeIds) {
+      const cf = cfById.get(id);
+      if (!cf) {
+        logger.warn(`Custom format group '${mapping.name}' (${mapping.trash_id}): include references unknown CF trash_id '${id}'.`);
+        continue;
+      }
+      selectedIds.push(id);
+    }
+  } else {
+    selectedIds = mapping.custom_formats.filter((cf) => cfIncludedInExplicitGroupExpansion(cf, includeUnrequired)).map((cf) => cf.trash_id);
+  }
+
+  const excludeSet = new Set(excludeIds);
+  const finalSet = new Set(selectedIds.filter((id) => !excludeSet.has(id)));
+
+  return mapping.custom_formats.map((cf) => cf.trash_id).filter((id) => finalSet.has(id));
+}
+
 export const transformTrashQPCFGroups = (
   template: TrashQP,
   trashCFGroupMapping: TrashCFGroupMapping,
   useExcludeSemantics: boolean = false,
+  includeDefaultOptionalCfs: boolean = true,
 ): ConfigCustomFormat[] => {
   const profileName = template.name;
   const results: ConfigCustomFormat[] = [];
 
   // Traverse each CF group and check for default=true
   for (const [_, cfGroup] of trashCFGroupMapping) {
-    // Check if the default prop is truthy (string "true")
-    if (cfGroup.default === "true") {
+    if (isTrashGroupDefaultEnabled(cfGroup)) {
       if (useExcludeSemantics) {
         // OLD BEHAVIOR: Check if template is excluded via exclude field
         const isExcluded = cfGroup.quality_profiles?.exclude?.[profileName] != null;
 
         if (!isExcluded) {
           // Include all required and default CFs from this group
-          const cfsToInclude = cfGroup.custom_formats.filter((cf) => cf.required || cf.default === true);
+          const cfsToInclude = cfGroup.custom_formats.filter((cf) => cf.required || (includeDefaultOptionalCfs && isCfDefaultSelected(cf)));
 
           if (cfsToInclude.length > 0) {
             logger.debug(
@@ -507,7 +580,7 @@ export const transformTrashQPCFGroups = (
 
         if (isIncluded) {
           // Include all required and default CFs from this group
-          const cfsToInclude = cfGroup.custom_formats.filter((cf) => cf.required || cf.default === true);
+          const cfsToInclude = cfGroup.custom_formats.filter((cf) => cf.required || (includeDefaultOptionalCfs && isCfDefaultSelected(cf)));
 
           if (cfsToInclude.length > 0) {
             logger.debug(
@@ -548,15 +621,29 @@ export const transformTrashQDs = (data: TrashQualityDefinition, ratio: number | 
   return transformQualities;
 };
 
-export const transformTrashCFGroups = (trashCFGroupMapping: TrashCFGroupMapping, groups: InputConfigCustomFormatGroup[]) => {
+export type TransformTrashCFGroupsOptions = {
+  silenceRequiredCfGroupExclusionWarnings?: boolean;
+};
+
+export const transformTrashCFGroups = (
+  trashCFGroupMapping: TrashCFGroupMapping,
+  groups: InputConfigCustomFormatGroup[],
+  options: TransformTrashCFGroupsOptions = {},
+) => {
+  const silenceRequiredExclusionWarnings = options.silenceRequiredCfGroupExclusionWarnings === true;
   return groups.reduce<ConfigCustomFormat[]>((p, c) => {
-    c.trash_guide?.forEach(({ id: trashId, include_unrequired }) => {
+    c.trash_guide?.forEach((guideItem) => {
+      const trashId = guideItem.id;
       const mapping = trashCFGroupMapping.get(trashId);
 
       if (mapping == null) {
         logger.warn(`Trash CustomFormat Group: ${trashId} is unknown.`);
       } else {
-        const groupCfs = mapping.custom_formats.filter((e) => e.required || include_unrequired === true).map((e) => e.trash_id);
+        const groupCfs = selectCustomFormatsForGroupExpansion(mapping, guideItem, silenceRequiredExclusionWarnings);
+
+        if (groupCfs.length === 0) {
+          return;
+        }
 
         const customFormatEntry = {
           trash_ids: groupCfs,

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -515,15 +515,19 @@ const applyAutoGroupSelectionOverrides = (
   let selected: TrashCFGItem[] = includeUnrequired ? cfGroup.custom_formats : baseSelection;
 
   if (options.includeCfs !== undefined) {
-    selected = includeIds
-      .map((id) => {
-        const cf = cfById.get(id);
-        if (!cf) {
-          logger.warn(`Auto TRaSH CF-group '${cfGroup.name}' (${cfGroup.trash_id}): include references unknown CF trash_id '${id}'.`);
-        }
-        return cf ?? null;
-      })
-      .filter(notEmpty);
+    const selectedIds = new Set(selected.map((cf) => cf.trash_id));
+    for (const id of includeIds) {
+      const cf = cfById.get(id);
+      if (!cf) {
+        logger.warn(`Auto TRaSH CF-group '${cfGroup.name}' (${cfGroup.trash_id}): include references unknown CF trash_id '${id}'.`);
+        continue;
+      }
+      if (selectedIds.has(id)) {
+        continue;
+      }
+      selected.push(cf);
+      selectedIds.add(id);
+    }
   }
 
   const excludeSet = new Set(excludeIds);
@@ -571,24 +575,25 @@ function selectCustomFormatsForGroupExpansion(
 
   const includeIds = dedupeIds(guideItem.include?.map((e) => e.id) ?? []);
 
-  let selectedIds: string[];
+  const selectedIds = mapping.custom_formats
+    .filter((cf) => cfIncludedInExplicitGroupExpansion(cf, includeUnrequired))
+    .map((cf) => cf.trash_id);
+  const selectedSet = new Set(selectedIds);
 
-  if (guideItem.include !== undefined) {
-    selectedIds = [];
-    for (const id of includeIds) {
-      const cf = cfById.get(id);
-      if (!cf) {
-        logger.warn(`Custom format group '${mapping.name}' (${mapping.trash_id}): include references unknown CF trash_id '${id}'.`);
-        continue;
-      }
-      selectedIds.push(id);
+  for (const id of includeIds) {
+    const cf = cfById.get(id);
+    if (!cf) {
+      logger.warn(`Custom format group '${mapping.name}' (${mapping.trash_id}): include references unknown CF trash_id '${id}'.`);
+      continue;
     }
-  } else {
-    selectedIds = mapping.custom_formats.filter((cf) => cfIncludedInExplicitGroupExpansion(cf, includeUnrequired)).map((cf) => cf.trash_id);
+    if (selectedSet.has(id)) {
+      continue;
+    }
+    selectedSet.add(id);
   }
 
   const excludeSet = new Set(excludeIds);
-  const finalSet = new Set(selectedIds.filter((id) => !excludeSet.has(id)));
+  const finalSet = new Set([...selectedSet].filter((id) => !excludeSet.has(id)));
 
   return mapping.custom_formats.map((cf) => cf.trash_id).filter((id) => finalSet.has(id));
 }

--- a/src/trash-guide.ts
+++ b/src/trash-guide.ts
@@ -12,6 +12,7 @@ import {
   ConfigQualityProfileItem,
   InputConfigCfGroupTrashGuideItem,
   InputConfigCustomFormatGroup,
+  InputConfigIncludeItem,
 } from "./types/config.types";
 import {
   TrashArrSupported,
@@ -492,6 +493,57 @@ const cfIncludedInExplicitGroupExpansion = (cf: TrashCFGItem, includeUnrequired:
 
 const dedupeIds = (ids: string[]): string[] => [...new Set(ids)];
 
+export type TransformTrashQPCFGroupsOptions = {
+  includeDefaultOptionalCfs?: boolean;
+  includeUnrequired?: boolean;
+  includeCfs?: InputConfigIncludeItem["trash_cfgroup_include_cfs"];
+  excludeCfs?: InputConfigIncludeItem["trash_cfgroup_exclude_cfs"];
+  silenceRequiredExclusionWarnings?: boolean;
+};
+
+const applyAutoGroupSelectionOverrides = (
+  cfGroup: TrashCustomFormatGroups,
+  baseSelection: TrashCFGItem[],
+  options: TransformTrashQPCFGroupsOptions,
+): TrashCFGItem[] => {
+  const includeUnrequired = options.includeUnrequired === true;
+  const includeIds = dedupeIds((options.includeCfs || []).map((e) => e.id));
+  const excludeIds = dedupeIds((options.excludeCfs || []).map((e) => e.id));
+
+  const cfById = new Map(cfGroup.custom_formats.map((cf) => [cf.trash_id, cf]));
+
+  let selected: TrashCFGItem[] = includeUnrequired ? cfGroup.custom_formats : baseSelection;
+
+  if (options.includeCfs !== undefined) {
+    selected = includeIds
+      .map((id) => {
+        const cf = cfById.get(id);
+        if (!cf) {
+          logger.warn(`Auto TRaSH CF-group '${cfGroup.name}' (${cfGroup.trash_id}): include references unknown CF trash_id '${id}'.`);
+        }
+        return cf ?? null;
+      })
+      .filter(notEmpty);
+  }
+
+  const excludeSet = new Set(excludeIds);
+  for (const id of excludeSet) {
+    const cf = cfById.get(id);
+    if (cf?.required === true) {
+      if (options.silenceRequiredExclusionWarnings) {
+        logger.debug(
+          `Auto TRaSH CF-group '${cfGroup.name}' (${cfGroup.trash_id}): exclude removes required CF '${cf.name}' (${id}) (silenced).`,
+        );
+      } else {
+        logger.warn(`Auto TRaSH CF-group '${cfGroup.name}' (${cfGroup.trash_id}): exclude removes required CF '${cf.name}' (${id}).`);
+      }
+    }
+  }
+
+  selected = selected.filter((cf) => !excludeSet.has(cf.trash_id));
+  return selected;
+};
+
 function selectCustomFormatsForGroupExpansion(
   mapping: TrashCustomFormatGroups,
   guideItem: InputConfigCfGroupTrashGuideItem,
@@ -545,10 +597,11 @@ export const transformTrashQPCFGroups = (
   template: TrashQP,
   trashCFGroupMapping: TrashCFGroupMapping,
   useExcludeSemantics: boolean = false,
-  includeDefaultOptionalCfs: boolean = true,
+  options: TransformTrashQPCFGroupsOptions = {},
 ): ConfigCustomFormat[] => {
   const profileName = template.name;
   const results: ConfigCustomFormat[] = [];
+  const includeDefaultOptionalCfs = options.includeDefaultOptionalCfs !== false;
 
   // Traverse each CF group and check for default=true
   for (const [_, cfGroup] of trashCFGroupMapping) {
@@ -559,7 +612,10 @@ export const transformTrashQPCFGroups = (
 
         if (!isExcluded) {
           // Include all required and default CFs from this group
-          const cfsToInclude = cfGroup.custom_formats.filter((cf) => cf.required || (includeDefaultOptionalCfs && isCfDefaultSelected(cf)));
+          const baseCfsToInclude = cfGroup.custom_formats.filter(
+            (cf) => cf.required || (includeDefaultOptionalCfs && isCfDefaultSelected(cf)),
+          );
+          const cfsToInclude = applyAutoGroupSelectionOverrides(cfGroup, baseCfsToInclude, options);
 
           if (cfsToInclude.length > 0) {
             logger.debug(
@@ -580,7 +636,10 @@ export const transformTrashQPCFGroups = (
 
         if (isIncluded) {
           // Include all required and default CFs from this group
-          const cfsToInclude = cfGroup.custom_formats.filter((cf) => cf.required || (includeDefaultOptionalCfs && isCfDefaultSelected(cf)));
+          const baseCfsToInclude = cfGroup.custom_formats.filter(
+            (cf) => cf.required || (includeDefaultOptionalCfs && isCfDefaultSelected(cf)),
+          );
+          const cfsToInclude = applyAutoGroupSelectionOverrides(cfGroup, baseCfsToInclude, options);
 
           if (cfsToInclude.length > 0) {
             logger.debug(

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -70,7 +70,7 @@ export type InputConfigCustomFormat = {
 export type InputConfigCfGroupTrashGuideItem = {
   id: string;
   include_unrequired?: boolean;
-  /** If set, only these CF `trash_id`s are taken from the group (must exist in the group JSON). */
+  /** If set, these CF `trash_id`s are added to the group base selection (must exist in the group JSON). */
   include?: { id: string }[];
   /** Remove these CF `trash_id`s from the selection; wins over `include` when both list the same id. */
   exclude?: { id: string }[];
@@ -96,7 +96,7 @@ export type InputConfigTrashCfGroupConfig = {
   include_unrequired?: boolean;
   /**
    * @experimental
-   * allow-list CF ids for TRaSH auto-group loading.
+   * add specific CF ids on top of TRaSH auto-group base selection.
    */
   include_cfs?: { id: string }[];
   /**
@@ -477,7 +477,7 @@ export type InputConfigIncludeItem = {
   /**
    * @experimental
    * TRaSH quality-profile include only:
-   * explicit allow-list of CF trash IDs from matched default groups.
+   * add CF trash IDs on top of matched default-group selection.
    */
   trash_cfgroup_include_cfs?: { id: string }[];
   /**

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -37,6 +37,7 @@ export type InputConfigSchema = {
   /**
    * Suppresses warnings when `custom_format_groups` excludes a CF that TRaSH marks as `required` in the cf-group JSON.
    * Sync behavior unchanged — only log output affected.
+   * @since v1.28.0
    * @default false
    */
   silenceRequiredCfGroupExclusionWarnings?: boolean;
@@ -81,6 +82,10 @@ export type InputConfigCustomFormatGroup = {
   assign_scores_to?: { name: string; score?: number }[];
 };
 
+/**
+ * @experimental
+ * @since v1.28.0
+ */
 export type InputConfigTrashCfGroupConfig = {
   /**
    * @experimental
@@ -214,11 +219,12 @@ export type InputConfigArrInstance = {
   };
   include?: InputConfigIncludeItem[];
   /**
-   * @experimental since v1.12.0
+   * @experimental since v1.12.0 (expanded cf-group semantics since v1.28.0)
    */
   custom_format_groups?: InputConfigCustomFormatGroup[];
   /**
    * @experimental
+   * @since v1.28.0
    * Instance-level defaults for TRaSH auto CF-group loading.
    * Can be overridden per include item with `trash_cfgroup_*` fields.
    */
@@ -463,6 +469,7 @@ export type InputConfigIncludeItem = {
   preferred_ratio?: number;
   /**
    * @experimental
+   * @since v1.28.0
    * TRaSH quality-profile include only:
    * include optional `default:true` CFs from default groups.
    * Defaults to instance-level setting, then true.
@@ -470,18 +477,21 @@ export type InputConfigIncludeItem = {
   trash_cfgroup_include_optional?: boolean;
   /**
    * @experimental
+   * @since v1.28.0
    * TRaSH quality-profile include only:
    * include all CFs from matched default groups.
    */
   trash_cfgroup_include_unrequired?: boolean;
   /**
    * @experimental
+   * @since v1.28.0
    * TRaSH quality-profile include only:
    * add CF trash IDs on top of matched default-group selection.
    */
   trash_cfgroup_include_cfs?: { id: string }[];
   /**
    * @experimental
+   * @since v1.28.0
    * TRaSH quality-profile include only:
    * explicit deny-list of CF trash IDs from matched default groups (wins over include).
    */

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -81,6 +81,31 @@ export type InputConfigCustomFormatGroup = {
   assign_scores_to?: { name: string; score?: number }[];
 };
 
+export type InputConfigTrashCfGroupConfig = {
+  /**
+   * @experimental
+   * include optional `default:true` CFs in TRaSH auto-group loading.
+   * @default true
+   */
+  include_optional?: boolean;
+  /**
+   * @experimental
+   * include all CFs from matched TRaSH groups.
+   * @default false
+   */
+  include_unrequired?: boolean;
+  /**
+   * @experimental
+   * allow-list CF ids for TRaSH auto-group loading.
+   */
+  include_cfs?: { id: string }[];
+  /**
+   * @experimental
+   * deny-list CF ids for TRaSH auto-group loading (wins over include).
+   */
+  exclude_cfs?: { id: string }[];
+};
+
 export type InputConfigRootFolderLidarr = {
   path: string;
   name: string;
@@ -193,37 +218,11 @@ export type InputConfigArrInstance = {
    */
   custom_format_groups?: InputConfigCustomFormatGroup[];
   /**
-   * Controls TRaSH quality-profile include behavior for default CF groups.
-   * When true (default), default group loading includes optional CFs marked `default: true`.
-   * When false, only `required: true` CFs are auto-loaded from default groups.
-   */
-  includeDefaultOptionalTrashGroupCfs?: boolean;
-  /**
    * @experimental
-   * Instance-level default for TRaSH quality-profile include auto-group behavior.
-   * If true, include optional `default:true` CFs in auto-loaded default groups.
-   * Per-include `trash_cfgroup_include_optional` overrides this.
+   * Instance-level defaults for TRaSH auto CF-group loading.
+   * Can be overridden per include item with `trash_cfgroup_*` fields.
    */
-  trash_cfgroup_include_optional?: boolean;
-  /**
-   * @experimental
-   * Instance-level default for TRaSH quality-profile include auto-group behavior.
-   * If true, include all CFs from matched default groups.
-   * Per-include `trash_cfgroup_include_unrequired` overrides this.
-   */
-  trash_cfgroup_include_unrequired?: boolean;
-  /**
-   * @experimental
-   * Instance-level default allow-list for auto-loaded TRaSH default groups.
-   * Per-include `trash_cfgroup_include_cfs` overrides this.
-   */
-  trash_cfgroup_include_cfs?: { id: string }[];
-  /**
-   * @experimental
-   * Instance-level default deny-list for auto-loaded TRaSH default groups.
-   * Per-include `trash_cfgroup_exclude_cfs` overrides this.
-   */
-  trash_cfgroup_exclude_cfs?: { id: string }[];
+  trash_cfgroup_config?: InputConfigTrashCfGroupConfig;
   custom_formats?: InputConfigCustomFormat[];
   // TODO this is not correct. The profile can be added partly -> InputConfigQualityProfile
   quality_profiles: ConfigQualityProfile[];

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -198,6 +198,32 @@ export type InputConfigArrInstance = {
    * When false, only `required: true` CFs are auto-loaded from default groups.
    */
   includeDefaultOptionalTrashGroupCfs?: boolean;
+  /**
+   * @experimental
+   * Instance-level default for TRaSH quality-profile include auto-group behavior.
+   * If true, include optional `default:true` CFs in auto-loaded default groups.
+   * Per-include `trash_cfgroup_include_optional` overrides this.
+   */
+  trash_cfgroup_include_optional?: boolean;
+  /**
+   * @experimental
+   * Instance-level default for TRaSH quality-profile include auto-group behavior.
+   * If true, include all CFs from matched default groups.
+   * Per-include `trash_cfgroup_include_unrequired` overrides this.
+   */
+  trash_cfgroup_include_unrequired?: boolean;
+  /**
+   * @experimental
+   * Instance-level default allow-list for auto-loaded TRaSH default groups.
+   * Per-include `trash_cfgroup_include_cfs` overrides this.
+   */
+  trash_cfgroup_include_cfs?: { id: string }[];
+  /**
+   * @experimental
+   * Instance-level default deny-list for auto-loaded TRaSH default groups.
+   * Per-include `trash_cfgroup_exclude_cfs` overrides this.
+   */
+  trash_cfgroup_exclude_cfs?: { id: string }[];
   custom_formats?: InputConfigCustomFormat[];
   // TODO this is not correct. The profile can be added partly -> InputConfigQualityProfile
   quality_profiles: ConfigQualityProfile[];
@@ -436,6 +462,31 @@ export type InputConfigIncludeItem = {
    * TRaSH quality definition. Has no effect for quality profile includes.
    */
   preferred_ratio?: number;
+  /**
+   * @experimental
+   * TRaSH quality-profile include only:
+   * include optional `default:true` CFs from default groups.
+   * Defaults to instance-level setting, then true.
+   */
+  trash_cfgroup_include_optional?: boolean;
+  /**
+   * @experimental
+   * TRaSH quality-profile include only:
+   * include all CFs from matched default groups.
+   */
+  trash_cfgroup_include_unrequired?: boolean;
+  /**
+   * @experimental
+   * TRaSH quality-profile include only:
+   * explicit allow-list of CF trash IDs from matched default groups.
+   */
+  trash_cfgroup_include_cfs?: { id: string }[];
+  /**
+   * @experimental
+   * TRaSH quality-profile include only:
+   * explicit deny-list of CF trash IDs from matched default groups (wins over include).
+   */
+  trash_cfgroup_exclude_cfs?: { id: string }[];
 };
 
 export type ConfigSchema = InputConfigSchema;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -34,6 +34,12 @@ export type InputConfigSchema = {
    * @default false
    */
   silenceTrashConflictWarnings?: boolean;
+  /**
+   * Suppresses warnings when `custom_format_groups` excludes a CF that TRaSH marks as `required` in the cf-group JSON.
+   * Sync behavior unchanged — only log output affected.
+   * @default false
+   */
+  silenceRequiredCfGroupExclusionWarnings?: boolean;
 
   sonarr?: Record<string, InputConfigArrInstance>;
   sonarrEnabled?: boolean;
@@ -60,8 +66,18 @@ export type InputConfigCustomFormat = {
   assign_scores_to?: { name: string; score?: number; use_default_score?: boolean }[];
 };
 
+/** One TRaSH cf-group reference under `custom_format_groups[].trash_guide`. */
+export type InputConfigCfGroupTrashGuideItem = {
+  id: string;
+  include_unrequired?: boolean;
+  /** If set, only these CF `trash_id`s are taken from the group (must exist in the group JSON). */
+  include?: { id: string }[];
+  /** Remove these CF `trash_id`s from the selection; wins over `include` when both list the same id. */
+  exclude?: { id: string }[];
+};
+
 export type InputConfigCustomFormatGroup = {
-  trash_guide?: { id: string; include_unrequired?: boolean }[];
+  trash_guide?: InputConfigCfGroupTrashGuideItem[];
   assign_scores_to?: { name: string; score?: number }[];
 };
 
@@ -176,6 +192,12 @@ export type InputConfigArrInstance = {
    * @experimental since v1.12.0
    */
   custom_format_groups?: InputConfigCustomFormatGroup[];
+  /**
+   * Controls TRaSH quality-profile include behavior for default CF groups.
+   * When true (default), default group loading includes optional CFs marked `default: true`.
+   * When false, only `required: true` CFs are auto-loaded from default groups.
+   */
+  includeDefaultOptionalTrashGroupCfs?: boolean;
   custom_formats?: InputConfigCustomFormat[];
   // TODO this is not correct. The profile can be added partly -> InputConfigQualityProfile
   quality_profiles: ConfigQualityProfile[];

--- a/src/types/trashguide.types.ts
+++ b/src/types/trashguide.types.ts
@@ -118,7 +118,7 @@ export type TrashCache = {
   };
 };
 
-type TrashCFGItem = {
+export type TrashCFGItem = {
   name: string;
   trash_id: string;
   /**
@@ -128,7 +128,7 @@ type TrashCFGItem = {
   /**
    * Selection if should be added even if required is false
    */
-  default?: boolean;
+  default?: boolean | string;
 };
 
 export type TrashCustomFormatGroups = {
@@ -139,7 +139,7 @@ export type TrashCustomFormatGroups = {
    * If this group should be added in always for TRaSH-Guide profiles
    * Should also be an boolean in theory but is an string in the guide
    */
-  default?: string;
+  default?: string | boolean;
   custom_formats: TrashCFGItem[];
   quality_profiles?: {
     /**


### PR DESCRIPTION
- closes #445 

## Summary by Sourcery

Align TRaSH custom format group handling with TRaSH semantics, adding configurable include/exclude controls, default-optional behavior, and warning suppression for required CF exclusions across both manual and auto-applied groups.

New Features:
- Support optional TRaSH CFs marked as default in cf-groups, including string-based defaults, and allow finer-grained include/exclude semantics per group reference.
- Introduce experimental, configurable overrides for auto-loaded TRaSH CF groups on both instance and include levels, including optional/unrequired CF inclusion and explicit allow/deny lists.
- Expose new configuration options to control default optional CF loading and to suppress warnings when excluding required CFs from TRaSH groups.

Enhancements:
- Refine TRaSH CF group expansion to deduplicate include/exclude IDs, prefer excludes over includes, and log when unknown or required CF IDs are referenced.
- Extend transform utilities for TRaSH CF and CF-group processing with reusable helpers and option types, and propagate these options through template merging and config transformation.
- Improve documentation to describe the new TRaSH CF group expansion semantics, experimental auto CF-group overrides, and related configuration options.

Tests:
- Add comprehensive tests covering new TRaSH CF group behaviors, including default optional handling, include/exclude precedence, warning silencing, unknown ID logging, empty selections, and propagation of global silence flags.
- Add tests verifying instance-level and include-level overrides for automatic TRaSH CF group loading and their interaction with required and optional CFs.