### PR TITLE
update package version, flake.lock, and fix eval warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773597492,
-        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/pkgs/nix/package.nix
+++ b/pkgs/nix/package.nix
@@ -46,8 +46,8 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "configarr";
 
   pnpmDeps = pkgs.fetchPnpmDeps {
-    fetcherVersion = 1;
-    hash = "sha256-qH2H7sJ3rMWutPUSpBtBTtIxQqwEUXFCyj+eoygdfjg=";
+    fetcherVersion = 3;
+    hash = "sha256-KAqoGHi8bWPUpzx+s5VWvJ7S+bc4iMZrKJUJUHkkazo=";
     inherit (finalAttrs) pname src version;
   };
 
@@ -55,8 +55,8 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "raydak-labs";
     repo = "configarr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Kd8EY+qTLv9AQGdLjqW2iU215g/ay9EKcMzTZej9dZk=";
+    hash = "sha256-ptns+s9qaf0COkHLFQW0LcQpU1qMK+5un0lRlAm6vSk=";
   };
 
-  version = "1.24.0";
+  version = "1.28.0";
 })


### PR DESCRIPTION
## Summary

1. Update `flake.lock`
2. Update package version in `pkgs/nix/package.nix` from `1.24.0` to `1.28.0`
3. Update pnpm fetcher version to 3

## Testing:

`nix build .#packages.x86_64-linux.default` succeeds with zero deprecation warnings

## Summary by Sourcery

Update the configarr Nix package to a newer upstream release and refresh its associated Nix flake lock data.

Bug Fixes:
- Address Nix evaluation deprecation warnings by switching the pnpm dependency fetcher to the newer version.

Enhancements:
- Bump the configarr package version from 1.24.0 to 1.28.0 and update its source and dependency hashes accordingly.

Build:
- Regenerate flake.lock to align with the updated package and fetcher configuration.