### PR TITLE
ci: harden workflows per zizmor audit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,59 +14,70 @@ on:
       - ".vscode/**"
       - "examples/**"
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       # Get the repositery's code
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Inject enhanced GitHub environment variables
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
         with:
           image: tonistiigi/binfmt:qemu-v8.1.5 # more recent
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       # We push and build all types of images only when required
       - name: Set build variables
         id: vars
+        env:
+          GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           # Set version based on tag or branch
-          VERSION="${{ env.GITHUB_REF_SLUG }}"
+          VERSION="${GITHUB_REF_SLUG}"
 
           # Set build timestamp
           BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "build_time=$BUILD_TIME" >> $GITHUB_OUTPUT
-          echo "run_id=${{ github.run_id }}" >> $GITHUB_OUTPUT
-          echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
-          echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "run_id=${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
+          echo "repo=${GITHUB_REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "sha=${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
       - name: Set build platforms
         id: set_platforms
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+          if [[ "${EVENT_NAME}" == 'workflow_dispatch' ]]; then
             echo "MANUAL_RUN=true" >> $GITHUB_OUTPUT
           else
             echo "MANUAL_RUN=false" >> $GITHUB_OUTPUT
           fi
 
-          if [[ ${{ github.event_name }} == 'workflow_dispatch' || ${{ github.ref }} == refs/tags/* ]]; then
+          if [[ "${EVENT_NAME}" == 'workflow_dispatch' || "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
             echo "push=true" >> $GITHUB_OUTPUT
           else
@@ -79,7 +90,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -87,14 +98,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta for PMS
         id: meta_pms
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -110,7 +121,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ steps.set_platforms.outputs.MANUAL_RUN == 'false' }}
 
       - name: Build and push PMS
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile
@@ -128,7 +139,7 @@ jobs:
 
       - name: Docker meta for alpine3.22 image
         id: meta_alpine322
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: |
             ghcr.io/raydak-labs/configarr
@@ -142,7 +153,7 @@ jobs:
             type=semver,pattern={{major}},suffix=-alpine3.22,enable=${{ steps.set_platforms.outputs.MANUAL_RUN == 'false' }}
 
       - name: Build and push alpine3.22 image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -12,12 +12,13 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build-cli:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -33,59 +34,68 @@ jobs:
             platform: windows-x64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Inject enhanced GitHub environment variables
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: latest
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
+          no-cache: true
 
       - name: Install deps
-        run: |
-          pnpm i
+        run: pnpm i
 
       - name: Set build variables
         id: vars
+        env:
+          GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
-          # Set version based on tag or branch
-          VERSION="${{ env.GITHUB_REF_SLUG }}"
-
-          # Set build timestamp
+          VERSION="${GITHUB_REF_SLUG}"
           BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "build_time=$BUILD_TIME" >> $GITHUB_OUTPUT
-          echo "run_id=${{ github.run_id }}" >> $GITHUB_OUTPUT
-          echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
-          echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "run_id=${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
+          echo "repo=${GITHUB_REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "sha=${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build CLI
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ steps.vars.outputs.version }}
+          BUILD_TIME: ${{ steps.vars.outputs.build_time }}
+          RUN_ID: ${{ steps.vars.outputs.run_id }}
+          REPO: ${{ steps.vars.outputs.repo }}
+          SHA: ${{ steps.vars.outputs.sha }}
+          BASELINE: ${{ github.event.inputs.baseline }}
         run: |
           FLAGS=""
 
-          # Set Windows-specific flags if building for Windows
-          if [[ "${{ matrix.platform }}" == windows-* ]]; then
-            # those flags are currently only supported when build in windows
-            #FLAGS="${FLAGS} --windows-title \"Configarr\" --windows-publisher \"BlackDark\" --windows-version \"${{ steps.vars.outputs.version }}\" --windows-description \"A powerful configuration management tool for *Arr applications\" --windows-copyright \"© 2025 BlackDark\""
+          if [[ "${PLATFORM}" == windows-* ]]; then
             echo "No custom flags for windows"
           else
             FLAGS="${FLAGS} --bytecode"
           fi
 
-          # Set baseline target if requested
-          if [[ "${{ github.event.inputs.baseline }}" == "true" ]]; then
+          if [[ "${BASELINE}" == "true" ]]; then
             FLAGS="${FLAGS} --target=bun"
           else
             echo "Non baseline build"
@@ -96,20 +106,20 @@ jobs:
           bun build src/index.ts \
             --compile --minify --sourcemap src/index.ts \
             --outfile configarr \
-            --define 'process.env.CONFIGARR_VERSION="${{ steps.vars.outputs.version }}"' \
-            --define 'process.env.BUILD_TIME="${{ steps.vars.outputs.build_time }}"' \
-            --define 'process.env.GITHUB_RUN_ID="${{ steps.vars.outputs.run_id }}"' \
-            --define 'process.env.GITHUB_REPO="${{ steps.vars.outputs.repo }}"' \
-            --define 'process.env.GITHUB_SHA="${{ steps.vars.outputs.sha }}"' \
-            --define 'process.env.BUILD_PLATFORM="${{ matrix.platform }}"' \
-            --target=${{ matrix.target }} \
+            --define 'process.env.CONFIGARR_VERSION="${VERSION}"' \
+            --define 'process.env.BUILD_TIME="${BUILD_TIME}"' \
+            --define 'process.env.GITHUB_RUN_ID="${RUN_ID}"' \
+            --define 'process.env.GITHUB_REPO="${REPO}"' \
+            --define 'process.env.GITHUB_SHA="${SHA}"' \
+            --define 'process.env.BUILD_PLATFORM="${PLATFORM}"' \
+            --target="${TARGET}" \
             $FLAGS
 
       - name: Compress CLI
         run: tar -cJf configarr-${{ matrix.platform }}.tar.xz configarr*
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: configarr-${{ matrix.platform }}.tar.xz
           path: configarr-${{ matrix.platform }}.tar.xz
@@ -119,9 +129,11 @@ jobs:
     needs: build-cli
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download CLI artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -137,8 +149,11 @@ jobs:
           ' _ {} \;
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: artifacts/**/configarr-*.tar.xz
-          generate_release_notes: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          shopt -s globstar nullglob
+          gh release create "${TAG_NAME}" \
+            artifacts/**/configarr-*.tar.xz \
+            --title "${TAG_NAME}"

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -7,6 +7,8 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -16,21 +18,22 @@ jobs:
       deployments: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Inject enhanced GitHub environment variables
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: latest
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Install & build
         working-directory: docs
@@ -38,18 +41,22 @@ jobs:
           pnpm i
           pnpm build
 
+      - name: Set deploy branch
+        id: deploy_branch
+        env:
+          DEPLOY_BRANCH: ${{ env.GITHUB_REF_SLUG_URL }}
+        run: echo "value=${DEPLOY_BRANCH}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         id: cloudflare-deploy
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./docs/build --project-name=configarr-preview --branch=${{ env.GITHUB_REF_SLUG_URL }}
-          # Optional: Enable this if you want to have GitHub Deployments triggered
-          #gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy ./docs/build --project-name=configarr-preview --branch=${{ steps.deploy_branch.outputs.value }}
 
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
         with:
           message: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,23 +8,28 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: latest
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Install & build
         working-directory: docs
@@ -34,30 +39,21 @@ jobs:
 
       - name: Upload static files as artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v4 # or specific "vX.X.X" version tag for this action
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: ./docs/build
 
-  # Deploy job
   deploy:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
-
-    # Add a dependency to the build job
     needs: build
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
-    # Specify runner + deployment step
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5 # or specific "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,19 +8,25 @@ on:
     branches-ignore:
       - prod
 
+permissions: {}
+
 jobs:
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: latest
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: pnpm

--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -3,33 +3,40 @@ name: release-it
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Generate a token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
-          app_id: ${{ secrets.RELEASER_APP_ID }}
-          private_key: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          permission-contents: write
+          permission-metadata: read
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: git config
         run: |
           git config user.email "raydak-releaser@users.noreply.github.com"
           git config user.name "raydak-releaser[bot]"
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: latest
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: pnpm
@@ -38,4 +45,4 @@ jobs:
 
       - run: pnpm release-it --ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: zizmor
+
+on:
+  pull_request:
+    paths:
+      - .github/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/**
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
Pin actions to SHAs, scope permissions per job, and pass shell values via env to block template injection. Disable package caches on publish workflows, replace archived github-app-token, and add a zizmor gate on workflow changes.

## Summary by Sourcery

Harden GitHub Actions workflows by tightening permissions, pinning third-party actions to specific SHAs, and adding automated security checks for workflow changes.

Enhancements:
- Scope GITHUB_TOKEN and job permissions minimally across all workflows, including separating read and write permissions per job.
- Pass GitHub context values via environment variables in shell steps to avoid direct templating and reduce injection risk.
- Disable package manager caching where not needed in CI and release workflows to simplify and harden build environments.
- Replace the archived github-app-token action with the supported create-github-app-token action for release automation.
- Switch CLI release creation from a third-party release action to the GitHub CLI for tighter control and reduced dependency surface.
- Pin all external GitHub Actions (checkout, Docker, pnpm, Node, Pages, Wrangler, artifact upload/download, etc.) to immutable commit SHAs for supply-chain security.
- Introduce a dedicated zizmor workflow that scans workflow files on PRs and main pushes to enforce secure CI configuration.