### PR TITLE
fix(config): propagate ui_config through mergeConfigsAndTemplates

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -748,6 +748,23 @@ describe("custom_formats ordering", () => {
     expect(ids).toEqual(["cf-group"]);
   });
 
+  test("should merge ui_config from instance config into merged config", async () => {
+    vi.spyOn(localImporter, "loadLocalRecyclarrTemplate").mockReturnValue(new Map());
+
+    const uiConfig = { theme: "dark", firstDayOfWeek: 0 };
+
+    const inputConfig: InputConfigArrInstance = {
+      quality_profiles: [],
+      ui_config: uiConfig,
+      api_key: "test",
+      base_url: "http://sonarr:8989",
+    };
+
+    const result = await mergeConfigsAndTemplates({}, inputConfig, "LIDARR");
+
+    expect(result.config.ui_config).toEqual(uiConfig);
+  });
+
   test("should propagate silenceRequiredCfGroupExclusionWarnings to include and instance custom_format_groups", async () => {
     const loggerWarnSpy = vi.spyOn(logger, "warn");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -800,6 +800,10 @@ export const mergeConfigsAndTemplates = async (
     mergedTemplates.media_management = { ...mergedTemplates.media_management, ...instanceConfig.media_management };
   }
 
+  if (instanceConfig.ui_config && Object.keys(instanceConfig.ui_config).length > 0) {
+    mergedTemplates.ui_config = { ...mergedTemplates.ui_config, ...instanceConfig.ui_config };
+  }
+
   if (instanceConfig.media_naming && Object.keys(instanceConfig.media_naming).length > 0) {
     mergedTemplates.media_naming_api = {
       ...mergedTemplates.media_naming_api,

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -76,6 +76,7 @@ export type MappedTemplates = Partial<
     | "media_management"
     | "media_naming"
     | "media_naming_api"
+    | "ui_config"
     | "delete_unmanaged_custom_formats"
     | "delete_unmanaged_quality_profiles"
     | "delete_unmanaged_metadata_profiles"


### PR DESCRIPTION
## Summary
- `ui_config` was defined on the instance config type and consumed by `syncUiConfig`, but `mergeConfigsAndTemplates` never copied it from the instance config into the merged config object (unlike its sibling `media_management`, which had the equivalent pass-through). As a result `config.ui_config` was always `undefined`, and users always saw `No UI config specified for <ARR>` regardless of what they configured under `ui_config:`.
- Added the missing merge block in `src/config.ts` mirroring the existing `media_management` handling.
- Added `ui_config` to the `MappedTemplates` `Pick` list in `src/types/common.types.ts` (it was missing there too).
- Added a regression test in `src/config.test.ts` covering the merge behavior.

Closes #470

## Test plan
- [x] `pnpm build`
- [x] `pnpm test` (344 tests passing, including new regression test)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

## Summary by Sourcery

Propagate ui_config from instance configuration into merged configuration and ensure it is included in template mapping to prevent missing UI config in merged configs.

Bug Fixes:
- Ensure ui_config from instance configs is merged into the final configuration so UI settings are no longer silently dropped.

Enhancements:
- Include ui_config in the MappedTemplates type so UI-related template data participates in the standard merge pipeline.

Tests:
- Add a regression test verifying that ui_config from an instance config is correctly merged into the resulting configuration.