### PR TITLE
fix(ci): fix release-it git push and enable release comments on PRs/issues

### DIFF
--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Generate a token
         id: generate_token
@@ -19,6 +21,8 @@ jobs:
           private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
           permission-contents: write
           permission-metadata: read
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -43,6 +43,12 @@ jobs:
 
       - run: pnpm install
 
+      - name: Configure git push credentials
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf '%s' "x-access-token:${GH_TOKEN}" | base64 | tr -d '\n')"
+
       - run: pnpm release-it --ci
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,7 @@
   "github": {
     "release": true,
     "comments": {
-      "submit": false
+      "submit": true
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

**1. Fix the failing `release-it` push (the reported pipeline failure)**
- The `Checkout code` step sets `persist-credentials: false` (added in the zizmor-hardening pass, since setup-node's pnpm cache combined with `persist-credentials: true` trips zizmor's credential-persistence audit). That means git has no stored auth by the time `release-it` runs its own `git push` for the version-bump commit/tag, so it failed with `fatal: could not read Username for 'https://github.com'`.
- Fix: add a step right after `pnpm install` (i.e. after any install/postinstall scripts already ran, so the earlier "untrusted code could steal the token" risk window is over) that injects the app token into the git config via an `http.extraheader`, the same mechanism `actions/checkout` uses internally when `persist-credentials: true`. `persist-credentials: false` stays on the checkout step itself.
- Verified `zizmor .github/workflows/release-it.yml` reports no findings on this branch (same as before the change).

**2. Auto-comment on released PRs/issues (linking which release shipped them)**
- Rather than bolting on a third-party action, `release-it` (already used here) ships this natively: `github.comments.submit`. Once a GitHub Release is published, release-it scans the changelog range and posts a `:rocket: this was released in vX.Y.Z` comment on every referenced PR/issue, using the same `GITHUB_TOKEN`/`github.release` config already in place.
- Flipped `.release-it.json`'s `github.comments.submit` from `false` to `true`.
- The app token needs `issues: write` / `pull-requests: write` to post those comments, so widened both the `create-github-app-token` `permission-*` inputs and the job-level `permissions:` block.
- **Manual step required outside this repo**: the `RELEASER` GitHub App installation itself must have "Issues" and "Pull requests" set to Read & write in its App permissions (and the installation re-approved if prompted) — otherwise `create-github-app-token` will reject the newly requested `permission-issues`/`permission-pull-requests` scopes at mint time.

Closes the pipeline failure from run https://github.com/raydak-labs/configarr/actions/runs/28738107297/job/85215858967

## Test plan
- [x] `zizmor .github/workflows/release-it.yml` — clean, no new findings
- [x] `pnpm exec release-it --dry-run --ci` locally — config parses, comments option accepted, no errors
- [x] `pnpm build && pnpm test && pnpm lint && pnpm typecheck`
- [ ] Re-run the `release-it` workflow via `workflow_dispatch` to confirm push/tag/comments succeed end-to-end (needs a live run with the real app token + the App permission update above)