### PR TITLE
fix(ci): give gh release create a repo context in CLI Release

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -151,6 +151,7 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           shopt -s globstar nullglob


### PR DESCRIPTION
## Summary
- The `v1.29.0` tag push (first real tag since the zizmor-hardening pass) exposed a regression in `CLI Release`'s `release` job: `gh release create` failed with `failed to run git: fatal: not a git repository (or any of the parent directories): .git`.
- Root cause: commit 3373844 ("ci: harden workflows per zizmor audit") replaced `softprops/action-gh-release@v2` (a JS action that talks to the GitHub API directly using `GITHUB_REPOSITORY`, no git needed) with a raw `gh release create` shell call — but the `release` job only downloads artifacts, it never checks out the repo. `gh` normally infers the target repo from the local git remote, which doesn't exist here.
- This went unnoticed because the only tag pushed since that change was the one used to test this exact bug (`v1.29.0`) — the prior real release (`v1.28.0`) predates the hardening commit.
- Fix: set `GH_REPO: ${{ github.repository }}` on the `Create Release` step so `gh` CLI knows the target repo without needing a local checkout (this is the documented, supported way to use `gh` outside of a git working directory — no need to add a checkout step just for this).

Related to the pipeline break reported after merging #472 / releasing v1.29.0. The `Documentation` workflow also failed in that run (`Deployment failed, try again later` from `actions/deploy-pages`), but that job has a 100% success history otherwise and no code in this repo changed to explain it — treating that one as a transient GitHub Pages API hiccup, to be re-run rather than "fixed".

## Test plan
- [x] `zizmor .github/workflows/cli-release.yml` — clean, no new findings
- [ ] Re-run/next tag push to confirm `gh release create` succeeds without a checkout step (can't fully verify locally — needs a real tag-triggered run)

## Summary by Sourcery

CI:
- Configure the CLI Release workflow’s Create Release step to pass GH_REPO from github.repository so gh release create has explicit repository context.