### PR TITLE
fix(ci): replace non-functional release-it comment feature with github-release-commenter

### DIFF
--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -1,0 +1,16 @@
+name: Release Comment
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: apexskier/github-release-commenter@e7813a9625eabd79a875b4bc4046cfcae377ab34 # v1.4.1

--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
-      pull-requests: write
     steps:
       - name: Generate a token
         id: generate_token
@@ -21,8 +19,6 @@ jobs:
           private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
           permission-contents: write
           permission-metadata: read
-          permission-issues: write
-          permission-pull-requests: write
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,7 @@
   "github": {
     "release": true,
     "comments": {
-      "submit": true
+      "submit": false
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

You were right to be suspicious — I checked the v1.29.0 release and confirmed **zero** automated comments were posted on any referenced PR/issue (#470, #450, #451, #444, #466, #452), even though the `release-it` log showed `✔ GitHub comment on resolved items`.

**Root cause** (traced into `node_modules/release-it/lib/plugin/github/{GitHub,util}.js`): release-it's `github.comments` feature works by regex-scanning the *rendered* `CHANGELOG.md` text for two patterns:
- `getCommitsFromChangelog`: `/\(([a-f0-9]{7,})\)/` — expects a bare `(abc1234)`
- `getResolvedIssuesFromChangelog` (via `issue-parser`): expects plain `closes #123`

Our `@release-it/conventional-changelog` config renders both as markdown links instead — `([abc1234](url))` and `closes [#123](url)` — and neither pattern matches a markdown link. I confirmed this directly by running both extraction functions against our actual changelog text; both return an empty array every time. So `commentOnResolvedItems()` always iterates over zero items and reports "success" having done nothing. This is a structural incompatibility between release-it's two own plugins, not something fixable by permissions or retrying.

**Fix:**
- `.release-it.json`: revert `github.comments.submit` to `false` — leaving it `true` is actively misleading (green checkmark, no effect).
- `.github/workflows/release-it.yml`: drop the `issues`/`pull-requests` scopes added for that feature (no longer needed here).
- Add `.github/workflows/release-comment.yml`, using [`apexskier/github-release-commenter`](https://github.com/apexskier/github-release-commenter) (pinned to `v1.4.1` / `e7813a9`), triggered on `release: published`. Unlike release-it's approach, this action determines affected PRs/issues from the **actual commit range** between releases via the GitHub API — not from rendered changelog text — so it isn't subject to the same parsing gap. It runs as its own workflow with a minimal-scope default `GITHUB_TOKEN` (`issues: write`, `pull-requests: write`), fully decoupled from the `release-it` job and its custom app token.
- Default `skip-label: dependencies` on the action conveniently skips commenting on routine Renovate PRs, which make up most of this repo's merge history, while still commenting on real fix/feature PRs and issues.

## Test plan
- [x] `zizmor` on both changed/new workflow files — clean, no findings
- [x] `pnpm exec release-it --dry-run --ci` — config still parses correctly with `comments.submit: false`
- [x] `pnpm build && pnpm test && pnpm lint && pnpm typecheck`
- [ ] Next real release (`release: published` event) will confirm `apexskier/github-release-commenter` actually posts comments — can't be verified locally

## Summary by Sourcery

Replace the broken release-it GitHub commenting mechanism with a dedicated release-comment workflow using github-release-commenter and tighten workflow permissions accordingly.

CI:
- Remove unnecessary issues and pull-requests write permissions from the release-it workflow.
- Add a new release-comment workflow that posts comments on related issues and pull requests when a release is published using github-release-commenter.