### PR TITLE
chore(ci): make CLI Release's Create Release step idempotent

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -148,13 +148,17 @@ jobs:
             rmdir "$dir/extracted" 2>/dev/null || true
           ' _ {} \;
 
-      - name: Create Release
+      - name: Create or update Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           shopt -s globstar nullglob
-          gh release create "${TAG_NAME}" \
-            artifacts/**/configarr-*.tar.xz \
-            --title "${TAG_NAME}"
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            gh release upload "${TAG_NAME}" artifacts/**/configarr-*.tar.xz --clobber
+          else
+            gh release create "${TAG_NAME}" \
+              artifacts/**/configarr-*.tar.xz \
+              --title "${TAG_NAME}"
+          fi


### PR DESCRIPTION
## Summary
- `v1.29.1`'s `CLI Release` failed again, but with a different, more informative error than last time: `a release with the same tag name already exists: v1.29.1` (exit code 1 from `gh release create`).
- Root cause: `release-it` (`github.release: true`) already creates the GitHub Release for the tag — with changelog notes — in the separate `release-it` workflow, *before* this tag-triggered `CLI Release` workflow gets to its `release` job. Plain `gh release create` always tries to create a brand-new release and fails if one already exists for that tag.
- This previously worked because the step used to be `softprops/action-gh-release@v2`, which is idempotent (create-if-missing, otherwise update the existing release and append assets). The zizmor-hardening pass (#457) swapped it for a raw `gh release create` shell call (to fix a different lint/security finding) without preserving that upsert behavior — it just never got exercised on a real tag push until now (see #473, which fixed the first-order bug in this same step: no git context for `gh` to infer the repo from).
- Fix: check `gh release view "${TAG_NAME}"` first; if a release already exists, attach the CLI binaries via `gh release upload --clobber` instead of trying to create a duplicate. Falls back to `gh release create` only when no release exists yet (e.g. a manual `workflow_dispatch` run not tied to an actual release-it release).

**Immediate fix applied by hand:** I downloaded the 5 build artifacts from the failed `v1.29.1` run and uploaded them directly to the existing `v1.29.1` GitHub release via `gh release upload`, so the release isn't missing its CLI binaries in the meantime.

## Test plan
- [x] `zizmor .github/workflows/cli-release.yml` — clean, no findings
- [x] Manually verified `v1.29.1` release now has all 5 platform archives attached
- [ ] Next tag push will confirm the upsert path works end-to-end (can't fully simulate the "release already exists" branch locally)

## Summary by Sourcery

Make the CLI Release workflow’s GitHub release step idempotent to handle existing tag releases.

Bug Fixes:
- Prevent CLI Release workflow failures when a GitHub release already exists for the pushed tag by conditionally uploading assets instead of always creating a new release.

CI:
- Update CLI Release workflow to detect existing releases and upload CLI artifacts with clobber semantics, only creating a new release when none exists.