### PR TITLE
docs: clarify conventional-commit types that do (not) hit the changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,16 @@ Each feature (quality profiles, custom formats, metadata profiles, root folders)
 - **Logging** - Use the `logger` instance for consistent logging
 - **Error handling** - Graceful degradation, informative error messages
 
+## Commit Message Conventions
+
+`release-it` + `@release-it/conventional-changelog` (see `.release-it.json`) auto-generate `CHANGELOG.md` and GitHub Release notes from commit messages. Only `feat`, `fix`, and `refactor` (as "(internal) Refactorings") produce changelog entries — every other type is silently omitted. Pick the type based on whether a **user** of configarr would care:
+
+- `feat:` / `fix:` — user-facing changes only: new features, behavior changes, bugs that affected the running application.
+- `ci:` or `chore(ci):` — GitHub Actions workflows, release pipeline, zizmor, etc. Never `fix(ci):` or `feat(ci):`, even when fixing a real bug in a workflow — it's not user-facing and would add a bogus entry to the changelog.
+- `docs:` — documentation-only changes.
+- `chore:` — tooling/maintenance with no functional impact (dependency bumps are already handled by Renovate as `chore(deps):` / `fix(deps):`).
+- `test:` / `style:` — test-only or formatting-only changes.
+
 ## Resources
 
 - **Documentation**: https://configarr.de


### PR DESCRIPTION
## Summary
- Adds a "Commit Message Conventions" section to `AGENTS.md` (symlinked from `CLAUDE.md`).
- `.release-it.json`'s conventional-changelog config only renders `feat`, `fix`, and `refactor` into `CHANGELOG.md`/release notes — every other type is silently dropped. That means CI-only fixes tagged `fix(ci): ...` (like #473/#475 in this session) show up in user-facing release notes even though nothing about the app itself changed.
- Documents that `ci:`/`chore(ci):` (never `fix(ci):`/`feat(ci):`), `docs:`, `chore:`, `test:`/`style:` should be used for their respective internal-only changes, reserving `feat`/`fix` for things a configarr user would actually care about.

## Test plan
- Docs-only change, no code/build/test impact.

## Summary by Sourcery

Documentation:
- Add guidance on conventional commit types and their impact on changelog and release notes generation.