### PR TITLE
fix(radarr): default omitted quality-profile language to Any on sync

### DIFF
--- a/src/clients/radarr-client.ts
+++ b/src/clients/radarr-client.ts
@@ -11,7 +11,7 @@ import {
 } from "../__generated__/radarr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
-import { cloneWithJSON } from "../util";
+import { ANY_LANGUAGE_NAME, cloneWithJSON } from "../util";
 import { IArrClient, logConnectionError, validateClientParams } from "./unified-client";
 
 export class RadarrClient implements IArrClient<QualityProfileResource, QualityDefinitionResource, CustomFormatResource, LanguageResource> {
@@ -64,7 +64,7 @@ export class RadarrClient implements IArrClient<QualityProfileResource, QualityD
     }
 
     if (profile.language == null) {
-      cloned.language = this.languageMap.get("Any");
+      cloned.language = this.languageMap.get(ANY_LANGUAGE_NAME);
     }
 
     return this.api.v3QualityprofileCreate(cloned);

--- a/src/clients/whisparr-client.ts
+++ b/src/clients/whisparr-client.ts
@@ -11,7 +11,7 @@ import {
 } from "../__generated__/whisparr/data-contracts";
 import { logger } from "../logger";
 import type { DownloadClientResource } from "../types/download-client.types";
-import { cloneWithJSON } from "../util";
+import { ANY_LANGUAGE_NAME, cloneWithJSON } from "../util";
 import { IArrClient, logConnectionError, validateClientParams } from "./unified-client";
 
 /**
@@ -77,7 +77,7 @@ export class WhisparrClient implements IArrClient<
     }
 
     if (profile.language == null) {
-      cloned.language = this.languageMap.get("Any");
+      cloned.language = this.languageMap.get(ANY_LANGUAGE_NAME);
     }
 
     return this.api.v3QualityprofileCreate(cloned);

--- a/src/quality-profiles.test.ts
+++ b/src/quality-profiles.test.ts
@@ -442,6 +442,105 @@ describe("QualityProfiles", async () => {
     expect(diff.noChanges.length).toBe(0);
   });
 
+  test("calculateQualityProfilesDiff - should default to Any language when not configured and server differs (radarr)", async ({}) => {
+    const cfMap: CFProcessing = { carrIdMapping: new Map(), cfNameToCarrConfig: new Map() };
+
+    const fromConfig: ConfigQualityProfileItem[] = [{ name: "HDTV-1080p", enabled: false }];
+
+    const resources: MergedQualityDefinitionResource[] = [
+      { id: 1, title: "HDTV-1080p", weight: 2, quality: { id: 1, name: "HDTV-1080p" } },
+    ];
+
+    const profile: ConfigQualityProfile = {
+      name: "hi",
+      min_format_score: 2,
+      qualities: fromConfig,
+      quality_sort: "top",
+      upgrade: { allowed: true, until_quality: "HDTV-1080p", until_score: 1000 },
+      score_set: "default",
+      // language intentionally omitted
+    };
+
+    const config: MergedConfigInstance = {
+      custom_formats: [],
+      quality_profiles: [profile],
+      customFormatDefinitions: [],
+      media_management: {},
+      media_naming: {},
+    };
+
+    const serverProfile = cloneWithJSON(sampleQualityProfile);
+    serverProfile.name = "hi";
+    serverProfile.formatItems = [];
+    serverProfile.minUpgradeFormatScore = 3;
+    serverProfile.minFormatScore = 2;
+    serverProfile.cutoff = 1;
+    serverProfile.items = [{ allowed: false, items: [], quality: { id: 1, name: "HDTV-1080p" } }];
+    serverProfile.language = { id: 1, name: "English" };
+
+    const serverQP: MergedQualityProfileResource[] = [serverProfile];
+    const serverQD: MergedQualityDefinitionResource[] = resources;
+    const serverCF: MergedCustomFormatResource[] = [cloneWithJSON(sampleCustomFormat)];
+
+    const serverCache = new ServerCache(serverQD, serverQP, serverCF, [{ id: 0, name: "Any" }]);
+
+    const diff = await calculateQualityProfilesDiff("RADARR", cfMap, config, serverCache);
+    expect(diff.changedQPs.length).toBe(1);
+    expect(diff.changedQPs[0]!.language).toEqual({ id: 0, name: "Any" });
+  });
+
+  test("calculateQualityProfilesDiff - should warn when default Any language is missing from server (radarr)", async ({}) => {
+    const cfMap: CFProcessing = { carrIdMapping: new Map(), cfNameToCarrConfig: new Map() };
+
+    const fromConfig: ConfigQualityProfileItem[] = [{ name: "HDTV-1080p", enabled: false }];
+
+    const resources: MergedQualityDefinitionResource[] = [
+      { id: 1, title: "HDTV-1080p", weight: 2, quality: { id: 1, name: "HDTV-1080p" } },
+    ];
+
+    const profile: ConfigQualityProfile = {
+      name: "hi",
+      min_format_score: 2,
+      qualities: fromConfig,
+      quality_sort: "top",
+      upgrade: { allowed: true, until_quality: "HDTV-1080p", until_score: 1000 },
+      score_set: "default",
+      // language intentionally omitted
+    };
+
+    const config: MergedConfigInstance = {
+      custom_formats: [],
+      quality_profiles: [profile],
+      customFormatDefinitions: [],
+      media_management: {},
+      media_naming: {},
+    };
+
+    const serverProfile = cloneWithJSON(sampleQualityProfile);
+    serverProfile.name = "hi";
+    serverProfile.formatItems = [];
+    serverProfile.minUpgradeFormatScore = 3;
+    serverProfile.minFormatScore = 2;
+    serverProfile.cutoff = 1;
+    serverProfile.items = [{ allowed: false, items: [], quality: { id: 1, name: "HDTV-1080p" } }];
+    serverProfile.language = { id: 1, name: "English" };
+
+    const serverQP: MergedQualityProfileResource[] = [serverProfile];
+    const serverQD: MergedQualityDefinitionResource[] = resources;
+    const serverCF: MergedCustomFormatResource[] = [cloneWithJSON(sampleCustomFormat)];
+
+    // No "Any" language present on the server
+    const serverCache = new ServerCache(serverQD, serverQP, serverCF, [{ id: 1, name: "English" }]);
+
+    const logSpy = vi.spyOn(log.logger, "warn").mockImplementation(() => {});
+
+    const diff = await calculateQualityProfilesDiff("RADARR", cfMap, config, serverCache);
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Any"));
+    expect(diff.changedQPs.length).toBe(0);
+    expect(diff.noChanges.length).toBe(1);
+  });
+
   test("calculateQualityProfilesDiff - should not diff for language (radarr)", async ({}) => {
     const cfMap: CFProcessing = { carrIdMapping: new Map(), cfNameToCarrConfig: new Map() };
 

--- a/src/quality-profiles.ts
+++ b/src/quality-profiles.ts
@@ -13,7 +13,7 @@ import { logger } from "./logger";
 import { ArrType, CFProcessing } from "./types/common.types";
 import { ConfigQualityProfile, ConfigQualityProfileItem, MergedConfigInstance } from "./types/config.types";
 import type { TrashCFConflict } from "./types/trashguide.types";
-import { cloneWithJSON, loadJsonFile, notEmpty, zip } from "./util";
+import { ANY_LANGUAGE_NAME, cloneWithJSON, loadJsonFile, notEmpty, zip } from "./util";
 
 export const deleteAllQualityProfiles = async () => {
   const api = getUnifiedClient();
@@ -334,6 +334,13 @@ export const calculateQualityProfilesDiff = async (
       if (profileLanguage == null) {
         logger.warn(`Profile language '${value.language}' not found in server. Ignoring.`);
         // profileLanguage = languageMap.get("Any");
+      }
+    } else if (arrType === "RADARR") {
+      // Radarr quality profiles always carry a language; default unmanaged/omitted language to "Any"
+      profileLanguage = languageMap.get(ANY_LANGUAGE_NAME);
+
+      if (profileLanguage == null) {
+        logger.warn(`Default language '${ANY_LANGUAGE_NAME}' not found in server. Ignoring.`);
       }
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -209,6 +209,9 @@ export const cloneWithJSON = <T>(input: T): T => {
 
 export const ROOT_PATH = path.resolve(process.cwd());
 
+/** Name of the built-in "any language" entry Radarr/Whisparr use as their quality-profile language default. */
+export const ANY_LANGUAGE_NAME = "Any";
+
 export const loadJsonFile = <T = object>(filePath: string) => {
   const file = readFileSync(filePath, { encoding: "utf-8" });
   return JSON.parse(file) as T;


### PR DESCRIPTION
## Summary

Investigated #458 ("Radarr: verify if profile has no language (empty) it will be auto configured to \"Any\"") against a live Radarr instance (`examples/full`).

**What already worked:** `RadarrClient.createQualityProfile` already defaults `language` to "Any" when creating a brand-new profile with no language configured (added back in 2024, `ffd6faae`).

**What was actually broken:** that default was create-only. `calculateQualityProfilesDiff` in `src/quality-profiles.ts` only computes a `profileLanguage` (and only ever flags a language diff) when the config *explicitly* names a language:

```ts
if (value.language) {
  profileLanguage = languageMap.get(value.language);
  ...
}
```

When `language` is omitted, `profileLanguage` stays `undefined`, and the update-diff check (`if (profileLanguage != null && ...)`) never fires — so an **existing** profile whose language drifted away from "Any" (edited directly in the Radarr UI, or created before the 2024 default existed) is never corrected back, even though a freshly-created profile with the same config would land on "Any".

### Reproduced live
1. Ran configarr against `examples/full`'s Radarr instance — confirmed a newly-created profile with no `language` in config got `language: Any` (create path already correct).
2. Manually PATCHed that profile's language to German directly via the Radarr API (simulating drift).
3. Re-ran configarr (before the fix) — profile reported `In Sync: true`, language stayed German. Bug confirmed.
4. Applied the fix, reran — log showed `Language diff: server: German - expected: Any`, profile updated, language back to `Any` on the server.
5. Ran once more — `In Sync: true`, confirming idempotency.

## Fix
In `calculateQualityProfilesDiff`, when config omits `language` **and** `arrType === "RADARR"`, default the expected language to "Any" (looked up from the server's language list) instead of leaving it `undefined`. Scoped to Radarr only — Sonarr/Lidarr/Readarr's `QualityProfileResource` type has no `language` field at all, and Whisparr's profile-language mapping is a separate, already-flagged "TODO: language not correctly mapped" issue in the example config, out of scope here.

## Test plan
- [x] New unit test: profile with no `language` configured + server drifted to a different language now produces a diff correcting it to "Any" (written first, watched it fail, then made it pass)
- [x] Existing language tests (explicit `language: "Any"`, diff/no-diff cases) still pass
- [x] `pnpm build && pnpm test && pnpm lint && pnpm typecheck`
- [x] Manually verified end-to-end against a live Radarr instance (steps above)

Closes #458