### PR TITLE
fix(delay-profiles): support Lidarr nightly protocol items

### DIFF
--- a/.github/workflows/arr-e2e.yml
+++ b/.github/workflows/arr-e2e.yml
@@ -1,0 +1,100 @@
+name: Arr E2E
+
+# Optional: run manually from Actions → Arr E2E → Run workflow
+on:
+  workflow_dispatch:
+    inputs:
+      run_delay_profile_tests:
+        description: Also run focused delay-profile API tests
+        type: boolean
+        default: true
+
+permissions: {}
+
+concurrency:
+  group: arr-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  arr-e2e:
+    name: Live *arr pipeline smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Start *arr stack
+        working-directory: tests/arr-e2e
+        env:
+          PUID: "1000"
+          PGID: "1000"
+        run: docker compose up -d
+
+      - name: Wait for *arr APIs
+        env:
+          API_KEY: e2etestapikey0123456789abcdef012
+        run: |
+          set -euo pipefail
+          wait_one() {
+            name="$1"
+            url="$2"
+            path="$3"
+            i=0
+            while [ "$i" -lt 90 ]; do
+              i=$((i + 1))
+              if curl -sf -H "X-Api-Key: ${API_KEY}" "${url}${path}" >/dev/null; then
+                echo "${name} ready (${i})"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "${name} failed to become ready"
+            docker compose -f tests/arr-e2e/docker-compose.yml logs --tail 80 "${name}" || true
+            return 1
+          }
+          wait_one sonarr   http://127.0.0.1:18989 /api/v3/system/status
+          wait_one radarr   http://127.0.0.1:17878 /api/v3/system/status
+          wait_one whisparr http://127.0.0.1:16969 /api/v3/system/status
+          wait_one readarr  http://127.0.0.1:18787 /api/v1/system/status
+          wait_one lidarr   http://127.0.0.1:18686 /api/v1/system/status
+
+      - name: Run full pipeline + delay-profile e2e
+        env:
+          ARR_E2E: "1"
+          RUN_DELAY_PROFILE_TESTS: ${{ inputs.run_delay_profile_tests }}
+        run: |
+          set -euo pipefail
+          if [ "${RUN_DELAY_PROFILE_TESTS}" = "true" ]; then
+            pnpm test:e2e:arr
+          else
+            pnpm exec vitest run --config vitest.arr-e2e.config.ts tests/arr-e2e/full-pipeline.e2e.test.ts
+          fi
+
+      - name: Dump compose logs on failure
+        if: failure()
+        working-directory: tests/arr-e2e
+        run: docker compose logs --tail 200
+
+      - name: Stop *arr stack
+        if: always()
+        working-directory: tests/arr-e2e
+        run: docker compose down -v

--- a/docs/docs/configuration/_include/config-file-sample.yml
+++ b/docs/docs/configuration/_include/config-file-sample.yml
@@ -93,6 +93,18 @@ sonarr:
     #     bypassIfHighestQuality: false
     #     bypassIfAboveCustomFormatScore: false
     #     minimumCustomFormatScore: 0
+    #   # Lidarr nightly (plugin support): use items instead of enableUsenet/enableTorrent (since v1.30.1)
+    #   # default:
+    #   #   items:
+    #   #     - name: Usenet
+    #   #       protocol: UsenetDownloadProtocol
+    #   #       allowed: true
+    #   #       delay: 2
+    #   #     - name: Torrent
+    #   #       protocol: TorrentDownloadProtocol
+    #   #       allowed: true
+    #   #       delay: 0
+    #   #   bypassIfHighestQuality: true
     #   additional:
     #     - enableUsenet: true
     #       enableTorrent: false

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -861,15 +861,47 @@ yourarr:
             - mytag
 ```
 
+### Protocol `items` (Lidarr nightly) <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.30.1</span>
+
+Lidarr **nightly** (plugin support) replaced the legacy Usenet/Torrent flags with a protocol `items` list. Custom protocols from plugins (for example Tubifarry) appear as extra entries in that list.
+
+```yaml
+lidarr:
+  instance1:
+    delay_profiles:
+      default:
+        items:
+          - name: Usenet
+            protocol: UsenetDownloadProtocol
+            allowed: true
+            delay: 2
+          - name: Torrent
+            protocol: TorrentDownloadProtocol
+            allowed: true
+            delay: 0
+          # Plugin protocols (example):
+          # - name: Youtube
+          #   protocol: YoutubeDownloadProtocol
+          #   allowed: false
+          #   delay: 0
+        bypassIfHighestQuality: true
+        bypassIfAboveCustomFormatScore: true
+        minimumCustomFormatScore: 0
+```
+
+YAML key `Items` is accepted as an alias for `items`.
+
+**Backward compatible:** existing configs that only set `enableUsenet` / `enableTorrent` / `preferredProtocol` / `usenetDelay` / `torrentDelay` keep working for Sonarr, Radarr, Whisparr, Readarr, and Lidarr stable. If `items` is set (non-empty), configarr sends the `items` payload and does **not** send the legacy protocol fields for that profile.
+
 Notes:
 
-- **experimental**, available since `v1.14.0`
+- **experimental**, available since `v1.14.0`; protocol `items` since `v1.30.1`
 - Supported for Sonarr, Radarr, Whisparr, Lidarr, and Readarr (if the API supports it)
 - If a delay profile exists on the server but not in your config, it will be deleted
 - If a delay profile is in your config but not on the server, it will be created (if supported)
 - If a delay profile differs, it will be updated
 
-See example [Radarr API DelayProfile](https://radarr.video/docs/api/#/DelayProfile) for more details on available fields.
+See example [Radarr API DelayProfile](https://radarr.video/docs/api/#/DelayProfile) for legacy fields. Lidarr nightly uses `items` instead.
 
 ## Download Clients <span className="theme-doc-version-badge badge badge--secondary configarr-badge">1.19.0</span>
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e:arr": "vitest run --config vitest.arr-e2e.config.ts",
     "typecheck": "tsc --noEmit",
     "release": "release-it"
   },

--- a/src/__generated__/lidarr/data-contracts.ts
+++ b/src/__generated__/lidarr/data-contracts.ts
@@ -669,7 +669,7 @@ export interface Field {
   helpText?: string | null;
   helpTextWarning?: string | null;
   helpLink?: string | null;
-  value?: any;
+  value?: any | null;
   type?: string | null;
   advanced?: boolean;
   selectOptions?: SelectOption[] | null;

--- a/src/__generated__/radarr/data-contracts.ts
+++ b/src/__generated__/radarr/data-contracts.ts
@@ -649,7 +649,7 @@ export interface Field {
   helpText?: string | null;
   helpTextWarning?: string | null;
   helpLink?: string | null;
-  value?: any;
+  value?: any | null;
   type?: string | null;
   advanced?: boolean;
   selectOptions?: SelectOption[] | null;
@@ -1484,8 +1484,8 @@ export interface ReleaseProfileResource {
   id?: number;
   name?: string | null;
   enabled?: boolean;
-  required?: any;
-  ignored?: any;
+  required?: any | null;
+  ignored?: any | null;
   /** @format int32 */
   indexerId?: number;
   /** @uniqueItems true */
@@ -1547,7 +1547,7 @@ export interface ReleaseResource {
   /** @format int32 */
   leechers?: number | null;
   protocol?: DownloadProtocol;
-  indexerFlags?: any;
+  indexerFlags?: any | null;
   /** @format int32 */
   movieId?: number | null;
   /** @format int32 */

--- a/src/__generated__/readarr/data-contracts.ts
+++ b/src/__generated__/readarr/data-contracts.ts
@@ -884,7 +884,7 @@ export interface Field {
   helpText?: string | null;
   helpTextWarning?: string | null;
   helpLink?: string | null;
-  value?: any;
+  value?: any | null;
   type?: string | null;
   advanced?: boolean;
   selectOptions?: SelectOption[] | null;

--- a/src/__generated__/sonarr/data-contracts.ts
+++ b/src/__generated__/sonarr/data-contracts.ts
@@ -616,7 +616,7 @@ export interface Field {
   helpText?: string | null;
   helpTextWarning?: string | null;
   helpLink?: string | null;
-  value?: any;
+  value?: any | null;
   type?: string | null;
   advanced?: boolean;
   selectOptions?: SelectOption[] | null;
@@ -1365,8 +1365,8 @@ export interface ReleaseProfileResource {
   id?: number;
   name?: string | null;
   enabled?: boolean;
-  required?: any;
-  ignored?: any;
+  required?: any | null;
+  ignored?: any | null;
   /** @format int32 */
   indexerId?: number;
   /** @uniqueItems true */

--- a/src/__generated__/whisparr/data-contracts.ts
+++ b/src/__generated__/whisparr/data-contracts.ts
@@ -596,7 +596,7 @@ export interface Field {
   helpText?: string | null;
   helpTextWarning?: string | null;
   helpLink?: string | null;
-  value?: any;
+  value?: any | null;
   type?: string | null;
   advanced?: boolean;
   selectOptions?: SelectOption[] | null;
@@ -1281,8 +1281,8 @@ export interface ReleaseProfileResource {
   id?: number;
   name?: string | null;
   enabled?: boolean;
-  required?: any;
-  ignored?: any;
+  required?: any | null;
+  ignored?: any | null;
   /** @format int32 */
   indexerId?: number;
   /** @uniqueItems true */

--- a/src/delay-profiles.test.ts
+++ b/src/delay-profiles.test.ts
@@ -293,4 +293,49 @@ describe("DelayProfiles", () => {
       { resourceType: "DelayProfile", name: "default", action: "update", fieldChanges: [{ field: "usenetDelay", from: 0, to: 10 }] },
     ]);
   });
+
+  test("mapToServerDelayProfile - items-only payload omits legacy protocol fields", async () => {
+    const { mapToServerDelayProfile } = await import("./delay-profiles");
+    const mapped = mapToServerDelayProfile(
+      {
+        items: [
+          { name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 2 },
+          { name: "Torrent", protocol: "TorrentDownloadProtocol", allowed: true, delay: 0 },
+          { name: "Youtube", protocol: "YoutubeDownloadProtocol", allowed: false, delay: 0 },
+        ],
+        bypassIfHighestQuality: true,
+        bypassIfAboveCustomFormatScore: true,
+        minimumCustomFormatScore: 0,
+      },
+      [],
+    );
+
+    expect(mapped).toEqual({
+      bypassIfHighestQuality: true,
+      bypassIfAboveCustomFormatScore: true,
+      minimumCustomFormatScore: 0,
+      order: undefined,
+      tags: [],
+      items: [
+        { name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 2 },
+        { name: "Torrent", protocol: "TorrentDownloadProtocol", allowed: true, delay: 0 },
+        { name: "Youtube", protocol: "YoutubeDownloadProtocol", allowed: false, delay: 0 },
+      ],
+    });
+    expect(mapped).not.toHaveProperty("preferredProtocol");
+    expect(mapped).not.toHaveProperty("enableUsenet");
+  });
+
+  test("InputConfigDelayProfileSchema - accepts Items alias", async () => {
+    const { InputConfigDelayProfileSchema } = await import("./types/config.types");
+    const parsed = InputConfigDelayProfileSchema.parse({
+      Items: [{ name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 2 }],
+      bypassIfHighestQuality: true,
+    });
+
+    expect(parsed).toEqual({
+      items: [{ name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 2 }],
+      bypassIfHighestQuality: true,
+    });
+  });
 });

--- a/src/delay-profiles.ts
+++ b/src/delay-profiles.ts
@@ -2,7 +2,7 @@ import { getUnifiedClient } from "./clients/unified-client";
 import { DiffEntry, FieldChange } from "./diffReport/diffReport.types";
 import { logger } from "./logger";
 import { InputConfigDelayProfile } from "./types/config.types";
-import { MergedDelayProfileResource, MergedTagResource } from "./types/merged.types";
+import { MergedDelayProfileProtocolItem, MergedDelayProfileResource, MergedTagResource } from "./types/merged.types";
 
 export const deleteAdditionalDelayProfiles = async () => {
   const api = getUnifiedClient();
@@ -43,17 +43,34 @@ export function splitServerDelayProfiles(serverProfiles: MergedDelayProfileResou
 
 export const mapToServerDelayProfile = (profile: InputConfigDelayProfile, serverTags: MergedTagResource[]): MergedDelayProfileResource => {
   const mappedTags = profile.tags?.map((tagName) => serverTags.find((t) => t.label === tagName)?.id).filter((t) => t !== undefined) || [];
-  return {
-    enableUsenet: profile.enableUsenet,
-    enableTorrent: profile.enableTorrent,
-    preferredProtocol: (profile.preferredProtocol ?? "usenet") as any, // Default to usenet if not specified
-    usenetDelay: profile.usenetDelay,
-    torrentDelay: profile.torrentDelay,
+  const shared = {
     bypassIfHighestQuality: profile.bypassIfHighestQuality,
     bypassIfAboveCustomFormatScore: profile.bypassIfAboveCustomFormatScore,
     minimumCustomFormatScore: profile.minimumCustomFormatScore,
     order: profile.order,
     tags: mappedTags,
+  };
+
+  // Lidarr nightly: items[] required. Prefer items when configured.
+  if (profile.items?.length) {
+    return {
+      ...shared,
+      items: profile.items.map((item) => ({
+        name: item.name,
+        protocol: item.protocol,
+        allowed: item.allowed,
+        delay: item.delay,
+      })),
+    };
+  }
+
+  return {
+    ...shared,
+    enableUsenet: profile.enableUsenet,
+    enableTorrent: profile.enableTorrent,
+    preferredProtocol: (profile.preferredProtocol ?? "usenet") as any, // Default to usenet if not specified
+    usenetDelay: profile.usenetDelay,
+    torrentDelay: profile.torrentDelay,
   };
 };
 
@@ -147,6 +164,21 @@ const getProfileTags = (profile: MergedDelayProfileResource): number[] => {
   return "tags" in profile && Array.isArray(profile.tags) ? profile.tags : [];
 };
 
+const normalizeDelayProfileItems = (items: MergedDelayProfileProtocolItem[] | null | undefined) =>
+  (items ?? []).map((item) => ({
+    name: item.name ?? undefined,
+    protocol: item.protocol ?? undefined,
+    allowed: item.allowed,
+    delay: item.delay,
+  }));
+
+const areDelayProfileItemsEqual = (
+  configItems: InputConfigDelayProfile["items"],
+  serverItems: MergedDelayProfileResource["items"],
+): boolean => {
+  return JSON.stringify(normalizeDelayProfileItems(configItems)) === JSON.stringify(normalizeDelayProfileItems(serverItems));
+};
+
 const compareProfileFields = (config: InputConfigDelayProfile, server: MergedDelayProfileResource): FieldChange[] => {
   const keys: ComparisonKeys[] = [
     "enableUsenet",
@@ -166,6 +198,11 @@ const compareProfileFields = (config: InputConfigDelayProfile, server: MergedDel
       changes.push({ field: key, from: server[key], to: config[key] });
     }
   }
+
+  if (config.items !== undefined && !areDelayProfileItemsEqual(config.items, server.items)) {
+    changes.push({ field: "items", from: server.items ?? [], to: config.items });
+  }
+
   return changes;
 };
 

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -193,18 +193,41 @@ export const InputConfigRemotePathSchema = z.object({
 });
 export type InputConfigRemotePath = z.infer<typeof InputConfigRemotePathSchema>;
 
-export const InputConfigDelayProfileSchema = z.object({
-  enableUsenet: z.boolean().optional(),
-  enableTorrent: z.boolean().optional(),
-  preferredProtocol: z.string().optional(),
-  usenetDelay: z.number().optional(),
-  torrentDelay: z.number().optional(),
-  bypassIfHighestQuality: z.boolean().optional(),
-  bypassIfAboveCustomFormatScore: z.boolean().optional(),
-  minimumCustomFormatScore: z.number().optional(),
-  order: z.number().optional(),
-  tags: z.array(z.string()).optional(),
+export const InputConfigDelayProfileItemSchema = z.object({
+  name: z.string(),
+  protocol: z.string(),
+  allowed: z.boolean().optional(),
+  delay: z.number().optional(),
 });
+export type InputConfigDelayProfileItem = z.infer<typeof InputConfigDelayProfileItemSchema>;
+
+// Lidarr nightly (plugin support) uses items[]; Sonarr/Radarr/etc. still use enableUsenet/enableTorrent.
+// Accept YAML `Items` as alias for `items`.
+export const InputConfigDelayProfileSchema = z.preprocess(
+  (raw) => {
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      const obj = raw as Record<string, unknown>;
+      if (obj.Items !== undefined && obj.items === undefined) {
+        const { Items, ...rest } = obj;
+        return { ...rest, items: Items };
+      }
+    }
+    return raw;
+  },
+  z.object({
+    enableUsenet: z.boolean().optional(),
+    enableTorrent: z.boolean().optional(),
+    preferredProtocol: z.string().optional(),
+    usenetDelay: z.number().optional(),
+    torrentDelay: z.number().optional(),
+    bypassIfHighestQuality: z.boolean().optional(),
+    bypassIfAboveCustomFormatScore: z.boolean().optional(),
+    minimumCustomFormatScore: z.number().optional(),
+    order: z.number().optional(),
+    tags: z.array(z.string()).optional(),
+    items: z.array(InputConfigDelayProfileItemSchema).optional(),
+  }),
+);
 export type InputConfigDelayProfile = z.infer<typeof InputConfigDelayProfileSchema>;
 
 export const InputConfigDownloadClientSchema = z.object({

--- a/src/types/merged.types.ts
+++ b/src/types/merged.types.ts
@@ -58,7 +58,18 @@ export type MergedQualityProfileResource = OmitTyped<QPRMerged, "items"> &
 
 export type MergedCustomFormatSpecificationSchema = RadarrCustomFormatSpecificationSchema & SonarrCustomFormatSpecificationSchema;
 export type MergedRootFolderResource = SonarrRootFolderResource & RadarrRootFolderResource;
+/** Lidarr nightly delay-profile protocol rows (openapi still stale; extend manually). */
+export type MergedDelayProfileProtocolItem = {
+  name?: string | null;
+  protocol?: string | null;
+  allowed?: boolean;
+  delay?: number;
+};
+
 export type MergedDelayProfileResource = import("../__generated__/sonarr/data-contracts").DelayProfileResource &
-  import("../__generated__/radarr/data-contracts").DelayProfileResource;
+  import("../__generated__/radarr/data-contracts").DelayProfileResource & {
+    name?: string | null;
+    items?: MergedDelayProfileProtocolItem[] | null;
+  };
 
 export type MergedTagResource = RadarrTagResource;

--- a/tests/arr-e2e/README.md
+++ b/tests/arr-e2e/README.md
@@ -1,0 +1,43 @@
+# *arr live e2e tests
+
+Opt-in Vitest suite against real *arr containers. **Not** part of `pnpm test`.
+
+Covers: **Sonarr**, **Radarr**, **Whisparr**, **Readarr**, **Lidarr** (nightly for `items[]`).
+
+## Start stack
+
+```bash
+cd tests/arr-e2e
+PUID=$(id -u) PGID=$(id -g) docker compose up -d
+```
+
+Runtime data lives in named Docker volumes; only `fixtures/*/config.xml` is bind-mounted.
+
+Wait until APIs respond (first boot can take ~30–90s), then:
+
+```bash
+ARR_E2E=1 pnpm test:e2e:arr
+```
+
+Default URLs / key (override with `SONARR_BASE_URL`, `SONARR_API_KEY`, …):
+
+| App      | URL                    | API key                            |
+| -------- | ---------------------- | ---------------------------------- |
+| Sonarr   | http://127.0.0.1:18989 | `e2etestapikey0123456789abcdef012` |
+| Radarr   | http://127.0.0.1:17878 | same                               |
+| Whisparr | http://127.0.0.1:16969 | same                               |
+| Readarr  | http://127.0.0.1:18787 | same                               |
+| Lidarr   | http://127.0.0.1:18686 | same                               |
+
+`ARR_E2E=1` required; without it the suite is skipped.
+
+## What is asserted
+
+1. **Full pipeline smoke** (`full-pipeline.e2e.test.ts`): runs real `configarr` twice against all five *arrs (CF/QP/delay/… pipeline). Asserts exit `0` and `Execution Summary` success `(1/0/0)` per type. Not field-level.
+2. **Delay profiles** (`delay-profiles.e2e.test.ts`):
+   - Sonarr / Radarr / Whisparr / Readarr — legacy delay-profile payload via `mapToServerDelayProfile`
+   - Lidarr nightly — legacy → 400; `items` → success (#481)
+
+## GitHub Actions (optional)
+
+Workflow **Arr E2E** is `workflow_dispatch` only (Actions → Arr E2E → Run workflow). Does not run on every PR.

--- a/tests/arr-e2e/delay-profiles.e2e.test.ts
+++ b/tests/arr-e2e/delay-profiles.e2e.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Live *arr delay-profile e2e for Sonarr, Radarr, Whisparr, Readarr, Lidarr.
+ *
+ *   cd tests/arr-e2e && PUID=$(id -u) PGID=$(id -g) docker compose up -d
+ *   ARR_E2E=1 pnpm test:e2e:arr
+ */
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { mapToServerDelayProfile } from "../../src/delay-profiles";
+import { InputConfigDelayProfileSchema } from "../../src/types/config.types";
+import { MergedDelayProfileResource } from "../../src/types/merged.types";
+import {
+  ARR_TARGETS,
+  LEGACY_DELAY_PROFILE,
+  LEGACY_DELAY_PROFILE_RESET,
+  arrE2eEnabled,
+  defaultDelayProfile,
+  resolveArrConnection,
+  type DelayProfileClient,
+} from "./helpers";
+
+const LEGACY_KINDS = ["sonarr", "radarr", "whisparr", "readarr"] as const;
+
+describe.runIf(arrE2eEnabled)("arr delay profiles (live)", () => {
+  for (const target of ARR_TARGETS.filter((t) => (LEGACY_KINDS as readonly string[]).includes(t.kind))) {
+    describe(target.kind, () => {
+      let client: DelayProfileClient;
+
+      beforeAll(async () => {
+        const { baseUrl, apiKey } = resolveArrConnection(target.kind, target.defaultBaseUrl);
+        client = target.createClient(baseUrl, apiKey);
+        const status = await client.getSystemStatus();
+        expect(String(status.version ?? "")).toBeTruthy();
+      }, 60_000);
+
+      afterAll(async () => {
+        await client.updateDelayProfile("1", LEGACY_DELAY_PROFILE_RESET);
+      });
+
+      test("mapToServerDelayProfile legacy payload updates default profile", async () => {
+        const parsed = InputConfigDelayProfileSchema.parse({
+          enableUsenet: true,
+          enableTorrent: true,
+          preferredProtocol: "usenet",
+          usenetDelay: 7,
+          torrentDelay: 3,
+          bypassIfHighestQuality: true,
+          bypassIfAboveCustomFormatScore: false,
+          minimumCustomFormatScore: 0,
+        });
+        const payload = mapToServerDelayProfile(parsed, []);
+        expect(payload.items).toBeUndefined();
+        expect(payload.enableUsenet).toBe(true);
+
+        await client.updateDelayProfile("1", payload);
+
+        const profiles = (await client.getDelayProfiles()) as MergedDelayProfileResource[];
+        const def = defaultDelayProfile(profiles);
+        expect(def).toBeDefined();
+        expect(def!.usenetDelay).toBe(7);
+        expect(def!.torrentDelay).toBe(3);
+        expect(def!.bypassIfHighestQuality).toBe(true);
+        expect(def!.preferredProtocol).toBe("usenet");
+      });
+    });
+  }
+
+  describe("lidarr nightly", () => {
+    const target = ARR_TARGETS.find((t) => t.kind === "lidarr")!;
+    let client: DelayProfileClient;
+
+    beforeAll(async () => {
+      const { baseUrl, apiKey } = resolveArrConnection(target.kind, target.defaultBaseUrl);
+      client = target.createClient(baseUrl, apiKey);
+      const status = await client.getSystemStatus();
+      expect(String(status.version ?? "")).toBeTruthy();
+    }, 60_000);
+
+    afterAll(async () => {
+      await client.updateDelayProfile("1", {
+        items: [
+          { name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 0 },
+          { name: "Torrent", protocol: "TorrentDownloadProtocol", allowed: true, delay: 0 },
+        ],
+        bypassIfHighestQuality: true,
+        bypassIfAboveCustomFormatScore: false,
+        minimumCustomFormatScore: 0,
+        tags: [],
+      });
+    });
+
+    test("legacy enableUsenet payload is rejected (Items must not be empty)", async () => {
+      await expect(client.updateDelayProfile("1", LEGACY_DELAY_PROFILE)).rejects.toThrow(/400/);
+    });
+
+    test("items config maps and updates successfully (#481)", async () => {
+      const parsed = InputConfigDelayProfileSchema.parse({
+        Items: [
+          { name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 2 },
+          { name: "Torrent", protocol: "TorrentDownloadProtocol", allowed: true, delay: 0 },
+        ],
+        bypassIfHighestQuality: true,
+        bypassIfAboveCustomFormatScore: true,
+        minimumCustomFormatScore: 0,
+      });
+
+      const payload = mapToServerDelayProfile(parsed, []);
+      expect(payload.items).toHaveLength(2);
+      expect(payload).not.toHaveProperty("enableUsenet");
+
+      await client.updateDelayProfile("1", payload);
+
+      const profiles = (await client.getDelayProfiles()) as MergedDelayProfileResource[];
+      const def = defaultDelayProfile(profiles);
+      expect(def).toBeDefined();
+      expect(def!.items).toEqual([
+        { name: "Usenet", protocol: "UsenetDownloadProtocol", allowed: true, delay: 2 },
+        { name: "Torrent", protocol: "TorrentDownloadProtocol", allowed: true, delay: 0 },
+      ]);
+      expect(def!.bypassIfHighestQuality).toBe(true);
+      expect(def!.bypassIfAboveCustomFormatScore).toBe(true);
+    });
+  });
+});

--- a/tests/arr-e2e/docker-compose.yml
+++ b/tests/arr-e2e/docker-compose.yml
@@ -1,0 +1,71 @@
+# Shared API key for all fixtures (must match helpers.ts DEFAULT_API_KEY)
+# Named volumes keep runtime DBs out of the repo; only config.xml is bind-mounted.
+services:
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.19
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Etc/UTC
+    volumes:
+      - sonarr-data:/config
+      - ./fixtures/sonarr-config/config.xml:/config/config.xml
+    ports:
+      - "18989:8989"
+
+  radarr:
+    image: lscr.io/linuxserver/radarr:6.2.1
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Etc/UTC
+    volumes:
+      - radarr-data:/config
+      - ./fixtures/radarr-config/config.xml:/config/config.xml
+    ports:
+      - "17878:7878"
+
+  whisparr:
+    image: ghcr.io/hotio/whisparr:v3-3.0.0.695
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - UMASK=002
+      - TZ=Etc/UTC
+    volumes:
+      - whisparr-data:/config
+      - ./fixtures/whisparr-config/config.xml:/config/config.xml
+    ports:
+      - "16969:6969"
+
+  readarr:
+    image: lscr.io/linuxserver/readarr:develop-0.4.3.2665-ls130
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Etc/UTC
+    volumes:
+      - readarr-data:/config
+      - ./fixtures/readarr-config/config.xml:/config/config.xml
+    ports:
+      - "18787:8787"
+
+  # Nightly required for protocol items[] (#481)
+  lidarr:
+    image: lscr.io/linuxserver/lidarr:nightly
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Etc/UTC
+    volumes:
+      - lidarr-data:/config
+      - ./fixtures/lidarr-config/config.xml:/config/config.xml
+    ports:
+      - "18686:8686"
+
+volumes:
+  sonarr-data:
+  radarr-data:
+  whisparr-data:
+  readarr-data:
+  lidarr-data:

--- a/tests/arr-e2e/fixtures/.gitignore
+++ b/tests/arr-e2e/fixtures/.gitignore
@@ -1,0 +1,10 @@
+# *arr containers write into fixture dirs when compose mounts them
+**/asp/
+**/*.db
+**/*.db-shm
+**/*.db-wal
+**/*.pid
+**/logs/
+**/MediaCover/
+**/Sentry/
+**/Backups/

--- a/tests/arr-e2e/fixtures/lidarr-config/config.xml
+++ b/tests/arr-e2e/fixtures/lidarr-config/config.xml
@@ -1,0 +1,14 @@
+<Config>
+  <BindAddress>*</BindAddress>
+  <Port>8686</Port>
+  <SslPort>9898</SslPort>
+  <EnableSsl>False</EnableSsl>
+  <ApiKey>e2etestapikey0123456789abcdef012</ApiKey>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
+  <Branch>nightly</Branch>
+  <LogLevel>info</LogLevel>
+  <UrlBase></UrlBase>
+  <InstanceName>Lidarr</InstanceName>
+  <UpdateMechanism>Docker</UpdateMechanism>
+</Config>

--- a/tests/arr-e2e/fixtures/radarr-config/config.xml
+++ b/tests/arr-e2e/fixtures/radarr-config/config.xml
@@ -1,0 +1,14 @@
+<Config>
+  <BindAddress>*</BindAddress>
+  <Port>7878</Port>
+  <SslPort>9898</SslPort>
+  <EnableSsl>False</EnableSsl>
+  <ApiKey>e2etestapikey0123456789abcdef012</ApiKey>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
+  <Branch>master</Branch>
+  <LogLevel>info</LogLevel>
+  <UrlBase></UrlBase>
+  <InstanceName>Radarr</InstanceName>
+  <UpdateMechanism>Docker</UpdateMechanism>
+</Config>

--- a/tests/arr-e2e/fixtures/readarr-config/config.xml
+++ b/tests/arr-e2e/fixtures/readarr-config/config.xml
@@ -1,0 +1,14 @@
+<Config>
+  <BindAddress>*</BindAddress>
+  <Port>8787</Port>
+  <SslPort>9898</SslPort>
+  <EnableSsl>False</EnableSsl>
+  <ApiKey>e2etestapikey0123456789abcdef012</ApiKey>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
+  <Branch>develop</Branch>
+  <LogLevel>info</LogLevel>
+  <UrlBase></UrlBase>
+  <InstanceName>Readarr</InstanceName>
+  <UpdateMechanism>Docker</UpdateMechanism>
+</Config>

--- a/tests/arr-e2e/fixtures/sonarr-config/config.xml
+++ b/tests/arr-e2e/fixtures/sonarr-config/config.xml
@@ -1,0 +1,14 @@
+<Config>
+  <BindAddress>*</BindAddress>
+  <Port>8989</Port>
+  <SslPort>9898</SslPort>
+  <EnableSsl>False</EnableSsl>
+  <ApiKey>e2etestapikey0123456789abcdef012</ApiKey>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
+  <Branch>main</Branch>
+  <LogLevel>info</LogLevel>
+  <UrlBase></UrlBase>
+  <InstanceName>Sonarr</InstanceName>
+  <UpdateMechanism>Docker</UpdateMechanism>
+</Config>

--- a/tests/arr-e2e/fixtures/whisparr-config/config.xml
+++ b/tests/arr-e2e/fixtures/whisparr-config/config.xml
@@ -1,0 +1,14 @@
+<Config>
+  <BindAddress>*</BindAddress>
+  <Port>6969</Port>
+  <SslPort>9898</SslPort>
+  <EnableSsl>False</EnableSsl>
+  <ApiKey>e2etestapikey0123456789abcdef012</ApiKey>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
+  <Branch>eros</Branch>
+  <LogLevel>info</LogLevel>
+  <UrlBase></UrlBase>
+  <InstanceName>Whisparr</InstanceName>
+  <UpdateMechanism>Docker</UpdateMechanism>
+</Config>

--- a/tests/arr-e2e/full-pipeline.e2e.test.ts
+++ b/tests/arr-e2e/full-pipeline.e2e.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Full configarr pipeline smoke against every *arr (no field-level asserts).
+ *
+ *   cd tests/arr-e2e && PUID=$(id -u) PGID=$(id -g) docker compose up -d
+ *   ARR_E2E=1 pnpm test:e2e:arr
+ */
+import { describe, expect, test } from "vitest";
+import {
+  ARR_TARGETS,
+  arrE2eEnabled,
+  assertPipelineSucceeded,
+  runConfigarr,
+  waitForAllArrApis,
+  writeFullPipelineWorkspace,
+} from "./helpers";
+
+describe.runIf(arrE2eEnabled)("configarr full pipeline (live)", () => {
+  test("runs end-to-end against sonarr/radarr/whisparr/readarr/lidarr without errors", async () => {
+    await waitForAllArrApis();
+
+    const { configLocation, repoPath, rootPath } = writeFullPipelineWorkspace();
+
+    const result = await runConfigarr({
+      CONFIG_LOCATION: configLocation,
+      ROOT_PATH: rootPath,
+      CUSTOM_REPO_ROOT: repoPath,
+      DRY_RUN: "false",
+      STOP_ON_ERROR: "true",
+      LOG_LEVEL: "info",
+      TELEMETRY_ENABLED: "false",
+    });
+
+    assertPipelineSucceeded(result);
+
+    // Second pass: idempotent re-sync should also succeed
+    const second = await runConfigarr({
+      CONFIG_LOCATION: configLocation,
+      ROOT_PATH: rootPath,
+      CUSTOM_REPO_ROOT: repoPath,
+      DRY_RUN: "false",
+      STOP_ON_ERROR: "true",
+      LOG_LEVEL: "info",
+      TELEMETRY_ENABLED: "false",
+    });
+
+    assertPipelineSucceeded(second);
+    expect(ARR_TARGETS).toHaveLength(5);
+  }, 600_000);
+});

--- a/tests/arr-e2e/helpers.ts
+++ b/tests/arr-e2e/helpers.ts
@@ -1,0 +1,239 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { LidarrClient } from "../../src/clients/lidarr-client";
+import { RadarrClient } from "../../src/clients/radarr-client";
+import { ReadarrClient } from "../../src/clients/readarr-client";
+import { SonarrClient } from "../../src/clients/sonarr-client";
+import { WhisparrClient } from "../../src/clients/whisparr-client";
+import { MergedDelayProfileResource } from "../../src/types/merged.types";
+
+export const DEFAULT_API_KEY = "e2etestapikey0123456789abcdef012";
+export const arrE2eEnabled = process.env.ARR_E2E === "1";
+
+export type ArrKind = "sonarr" | "radarr" | "whisparr" | "readarr" | "lidarr";
+
+export type DelayProfileClient = {
+  getSystemStatus: () => Promise<{ version?: string | null; appName?: string | null }>;
+  getDelayProfiles: () => Promise<any[]>;
+  updateDelayProfile: (id: string, data: any) => Promise<any>;
+};
+
+type ArrTarget = {
+  kind: ArrKind;
+  defaultBaseUrl: string;
+  statusPath: string;
+  createClient: (baseUrl: string, apiKey: string) => DelayProfileClient;
+};
+
+export const ARR_TARGETS: ArrTarget[] = [
+  {
+    kind: "sonarr",
+    defaultBaseUrl: "http://127.0.0.1:18989",
+    statusPath: "/api/v3/system/status",
+    createClient: (baseUrl, apiKey) => new SonarrClient(baseUrl, apiKey),
+  },
+  {
+    kind: "radarr",
+    defaultBaseUrl: "http://127.0.0.1:17878",
+    statusPath: "/api/v3/system/status",
+    createClient: (baseUrl, apiKey) => new RadarrClient(baseUrl, apiKey),
+  },
+  {
+    kind: "whisparr",
+    defaultBaseUrl: "http://127.0.0.1:16969",
+    statusPath: "/api/v3/system/status",
+    createClient: (baseUrl, apiKey) => new WhisparrClient(baseUrl, apiKey),
+  },
+  {
+    kind: "readarr",
+    defaultBaseUrl: "http://127.0.0.1:18787",
+    statusPath: "/api/v1/system/status",
+    createClient: (baseUrl, apiKey) => new ReadarrClient(baseUrl, apiKey),
+  },
+  {
+    kind: "lidarr",
+    defaultBaseUrl: "http://127.0.0.1:18686",
+    statusPath: "/api/v1/system/status",
+    createClient: (baseUrl, apiKey) => new LidarrClient(baseUrl, apiKey),
+  },
+];
+
+export function resolveArrConnection(kind: ArrKind, defaultBaseUrl: string): { baseUrl: string; apiKey: string } {
+  const upper = kind.toUpperCase();
+  return {
+    baseUrl: process.env[`${upper}_BASE_URL`] ?? defaultBaseUrl,
+    apiKey: process.env[`${upper}_API_KEY`] ?? DEFAULT_API_KEY,
+  };
+}
+
+export const LEGACY_DELAY_PROFILE = {
+  enableUsenet: true,
+  enableTorrent: true,
+  preferredProtocol: "usenet" as const,
+  usenetDelay: 7,
+  torrentDelay: 3,
+  bypassIfHighestQuality: true,
+  bypassIfAboveCustomFormatScore: false,
+  minimumCustomFormatScore: 0,
+  tags: [] as number[],
+};
+
+export const LEGACY_DELAY_PROFILE_RESET = {
+  ...LEGACY_DELAY_PROFILE,
+  usenetDelay: 0,
+  torrentDelay: 0,
+  bypassIfHighestQuality: false,
+};
+
+export function defaultDelayProfile(profiles: MergedDelayProfileResource[]): MergedDelayProfileResource | undefined {
+  return profiles.find((p) => !p.tags?.length) ?? profiles[0];
+}
+
+export async function waitForArrApi(baseUrl: string, apiKey: string, statusPath: string, timeoutMs = 180_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}${statusPath}`, { headers: { "X-Api-Key": apiKey } });
+      if (res.ok) return;
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  throw new Error(`Timed out waiting for ${baseUrl}${statusPath}: ${String(lastError)}`);
+}
+
+export async function waitForAllArrApis(timeoutMs = 180_000): Promise<void> {
+  await Promise.all(
+    ARR_TARGETS.map(async (target) => {
+      const { baseUrl, apiKey } = resolveArrConnection(target.kind, target.defaultBaseUrl);
+      await waitForArrApi(baseUrl, apiKey, target.statusPath, timeoutMs);
+    }),
+  );
+}
+
+function delayProfilesYaml(kind: ArrKind): string {
+  if (kind === "lidarr") {
+    return `    delay_profiles:
+      default:
+        items:
+          - name: Usenet
+            protocol: UsenetDownloadProtocol
+            allowed: true
+            delay: 1
+          - name: Torrent
+            protocol: TorrentDownloadProtocol
+            allowed: true
+            delay: 0
+        bypassIfHighestQuality: true
+        bypassIfAboveCustomFormatScore: false
+        minimumCustomFormatScore: 0`;
+  }
+
+  return `    delay_profiles:
+      default:
+        enableUsenet: true
+        enableTorrent: true
+        preferredProtocol: usenet
+        usenetDelay: 1
+        torrentDelay: 0
+        bypassIfHighestQuality: true
+        bypassIfAboveCustomFormatScore: false
+        minimumCustomFormatScore: 0`;
+}
+
+/** Minimal config that still exercises the full configarr pipeline for every *arr. */
+export function buildFullPipelineConfigYaml(): string {
+  const blocks = ARR_TARGETS.map((target) => {
+    const { baseUrl, apiKey } = resolveArrConnection(target.kind, target.defaultBaseUrl);
+    return `${target.kind}:
+  e2e:
+    base_url: ${baseUrl}
+    api_key: ${apiKey}
+${delayProfilesYaml(target.kind)}
+`;
+  });
+
+  return `# generated by arr-e2e full-pipeline smoke
+telemetry: false
+
+${blocks.join("\n")}`;
+}
+
+export function writeFullPipelineWorkspace(): { rootPath: string; configLocation: string; repoPath: string } {
+  const rootPath = mkdtempSync(join(tmpdir(), "configarr-arr-e2e-"));
+  const configDir = join(rootPath, "config");
+  const repoPath = join(rootPath, "repos");
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(repoPath, { recursive: true });
+
+  const configLocation = join(configDir, "config.yml");
+  writeFileSync(configLocation, buildFullPipelineConfigYaml(), "utf8");
+
+  return { rootPath, configLocation, repoPath };
+}
+
+export type ConfigarrRunResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+export async function runConfigarr(env: Record<string, string>, timeoutMs = 300_000): Promise<ConfigarrRunResult> {
+  const repoRoot = join(import.meta.dirname, "../..");
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["exec", "tsx", "src/index.ts"], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`configarr timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(timer);
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+export function assertPipelineSucceeded(result: ConfigarrRunResult, kinds: ArrKind[] = ARR_TARGETS.map((t) => t.kind)): void {
+  if (result.exitCode !== 0) {
+    throw new Error(`configarr exited ${result.exitCode}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`);
+  }
+
+  for (const kind of kinds) {
+    const upper = kind.toUpperCase();
+    // Example: LIDARR: (1/0/0)
+    const re = new RegExp(`${upper}: \\(1/0/0\\)`);
+    if (!re.test(result.stdout)) {
+      throw new Error(`Missing success summary for ${upper} in:\n${result.stdout}`);
+    }
+  }
+
+  if (/Stopping further execution because 'STOP_ON_ERROR'/.test(result.stdout + result.stderr)) {
+    throw new Error("STOP_ON_ERROR triggered during pipeline");
+  }
+}

--- a/vitest.arr-e2e.config.ts
+++ b/vitest.arr-e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/arr-e2e/**/*.e2e.test.ts"],
+    testTimeout: 600_000,
+    hookTimeout: 180_000,
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Fix Lidarr nightly delay-profile sync (`Items must not be empty`) by accepting/sending protocol `items` (YAML `Items` alias too). Closes #481.
- Keep legacy `enableUsenet` / `enableTorrent` / delays for Sonarr, Radarr, Whisparr, Readarr, and Lidarr stable — **backward compatible** when `items` is omitted.
- Regenerate *arr API types (openapi still lacks Lidarr `items`; extended in `merged.types.ts`).
- Docs: protocol `items` since **v1.30.1** (expected next patch after 1.30.0).
- Opt-in live e2e: `ARR_E2E=1 pnpm test:e2e:arr` against Lidarr nightly.

## Backward compatibility
| Config | Behavior |
|--------|----------|
| Only legacy fields | Unchanged payload for all *arrs that still use that API |
| Non-empty `items` | Sends `items` only (no legacy protocol fields) — required for Lidarr nightly |

## Test plan
- [x] `pnpm build && pnpm test && pnpm lint && pnpm typecheck`
- [x] Live Lidarr nightly: legacy PUT → 400; items PUT → success
- [x] Full `pnpm start` against Lidarr nightly with issue #481-style config
- [x] `ARR_E2E=1 pnpm test:e2e:arr` (2 passed)
- [ ] Confirm release version badge `1.30.1` matches the actual release that ships this (adjust if release-it bumps differently)

## Summary by Sourcery

Support Lidarr nightly delay-profile protocol items while preserving backward compatibility with legacy delay-profile fields across *arr services.

New Features:
- Add support for delay-profile protocol items and YAML `Items` alias in configuration for Lidarr nightly and compatible *arr instances.
- Introduce opt-in live e2e test suite for *arr services, starting with Lidarr nightly delay-profile items, runnable via a dedicated test script.

Bug Fixes:
- Fix delay-profile synchronization with Lidarr nightly by sending `items`-based payloads instead of legacy protocol flags when protocol items are configured.

Enhancements:
- Extend merged delay profile resource types to include Lidarr nightly protocol item fields and improve delay-profile comparison logic to handle items arrays.
- Refine delay-profile mapping to omit legacy protocol fields when protocol items are present, maintaining compatibility with existing configurations.

Build:
- Add a dedicated npm script to run *arr e2e tests via Vitest.

Documentation:
- Document protocol `items` support for Lidarr nightly delay profiles, including configuration examples and version notes.
- Add documentation for running *arr live e2e tests against a Lidarr nightly container.

Tests:
- Add unit tests for delay-profile item mapping and `Items` YAML alias parsing.
- Add live e2e tests and Vitest config for Lidarr nightly delay-profile items, gated behind an environment flag.