### PR TITLE
update flake.lock, update nix package version to 1.30.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1784783405,
+        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {

--- a/pkgs/nix/package.nix
+++ b/pkgs/nix/package.nix
@@ -46,8 +46,8 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "configarr";
 
   pnpmDeps = pkgs.fetchPnpmDeps {
-    fetcherVersion = 3;
-    hash = "sha256-KAqoGHi8bWPUpzx+s5VWvJ7S+bc4iMZrKJUJUHkkazo=";
+    fetcherVersion = 4;
+    hash = "sha256-KPCJJPqHwLPmQoPLqae3huAiX/OeJneD8CxIBV9wjZU=";
     inherit (finalAttrs) pname src version;
   };
 
@@ -55,8 +55,8 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "raydak-labs";
     repo = "configarr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ptns+s9qaf0COkHLFQW0LcQpU1qMK+5un0lRlAm6vSk=";
+    hash = "sha256-SVirTU+zdIeavOFPuZW09BEzV1N+ZfYD/YJuHwtlr1Q=";
   };
 
-  version = "1.28.0";
+  version = "1.30.1";
 })


### PR DESCRIPTION
Fixes https://github.com/raydak-labs/configarr/issues/480

## Summary by Sourcery

Update Nix packaging and lockfile to use the latest Configarr release.

Build:
- Bump Configarr Nix package version from 1.28.0 to 1.30.1 and refresh source and pnpm dependency hashes.
- Update pnpm dependency fetcher configuration to use the newer fetcher version.
- Regenerate flake.lock to align with the updated Nix package inputs.

Chores:
- Align Nix packaging with the latest upstream Configarr release addressing issue #480.