### PR TITLE
fix: don't crash when a legacy recyclarr includes directory is missing

### DIFF
--- a/src/recyclarr-importer.test.ts
+++ b/src/recyclarr-importer.test.ts
@@ -1,0 +1,47 @@
+import { default as fs } from "node:fs";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { loadRecyclarrTemplates } from "./recyclarr-importer";
+
+vi.mock("./logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("recyclarr-importer", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("loadRecyclarrTemplates", () => {
+    test("does not throw when a legacy includes directory does not exist", () => {
+      // Regression test for https://github.com/raydak-labs/configarr/issues/504
+      // recyclarr/config-templates removed sonarr/includes and radarr/includes entirely,
+      // which previously crashed every run with ENOENT regardless of which templates a
+      // user's config actually referenced.
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      const readdirSpy = vi.spyOn(fs, "readdirSync");
+
+      expect(() => loadRecyclarrTemplates("SONARR")).not.toThrow();
+      expect(loadRecyclarrTemplates("SONARR").size).toBe(0);
+      expect(loadRecyclarrTemplates("RADARR").size).toBe(0);
+      expect(readdirSpy).not.toHaveBeenCalled();
+    });
+
+    test("still loads templates when the legacy includes directory exists", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readdirSync").mockReturnValue(["example-template.yml"] as any);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        "custom_formats:\n  - trash_ids: [abc]\n    assign_scores_to:\n      - name: Some Profile\n",
+      );
+
+      const map = loadRecyclarrTemplates("SONARR");
+
+      expect(map.size).toBeGreaterThan(0);
+      expect(map.get("example-template")).toBeDefined();
+    });
+  });
+});

--- a/src/recyclarr-importer.test.ts
+++ b/src/recyclarr-importer.test.ts
@@ -17,17 +17,17 @@ describe("recyclarr-importer", () => {
   });
 
   describe("loadRecyclarrTemplates", () => {
-    test("does not throw when a legacy includes directory does not exist", () => {
+    test.each(["SONARR", "RADARR"] as const)("does not throw when a legacy includes directory does not exist (%s)", (arrType) => {
       // Regression test for https://github.com/raydak-labs/configarr/issues/504
       // recyclarr/config-templates removed sonarr/includes and radarr/includes entirely,
       // which previously crashed every run with ENOENT regardless of which templates a
       // user's config actually referenced.
-      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => !String(path).includes("includes"));
       const readdirSpy = vi.spyOn(fs, "readdirSync");
 
-      expect(() => loadRecyclarrTemplates("SONARR")).not.toThrow();
-      expect(loadRecyclarrTemplates("SONARR").size).toBe(0);
-      expect(loadRecyclarrTemplates("RADARR").size).toBe(0);
+      const map = loadRecyclarrTemplates(arrType);
+
+      expect(map.size).toBe(0);
       expect(readdirSpy).not.toHaveBeenCalled();
     });
 

--- a/src/recyclarr-importer.ts
+++ b/src/recyclarr-importer.ts
@@ -28,6 +28,15 @@ export const loadRecyclarrTemplates = (arrType: RecyclarrArrSupported): Map<stri
   const map = new Map<string, RecyclarrTemplates>();
 
   const fillMap = (path: string) => {
+    if (!fs.existsSync(path)) {
+      // Upstream (recyclarr/config-templates) has moved away from these legacy per-item
+      // include directories in favor of bundled templates, so they may no longer exist
+      // at all for a given arrType/revision. Treat that as "no legacy templates found"
+      // rather than crashing, matching loadLocalRecyclarrTemplate's existsSync guard.
+      logger.debug(`Recyclarr template directory '${path}' does not exist. Skipping.`);
+      return;
+    }
+
     const files = fs
       .readdirSync(`${path}`, { recursive: true, encoding: "utf8" })
       .filter((fn) => fn.endsWith("yaml") || fn.endsWith("yml"));


### PR DESCRIPTION
## Summary

Fixes #504.

`recyclarr/config-templates` removed the legacy `sonarr/includes/` and `radarr/includes/` directories entirely, replacing them with bundled templates (upstream commits around `124c703fc0`, `fa051c0fb9`, `9faf65ff74` on 2026-08-07). `loadRecyclarrTemplates` in `src/recyclarr-importer.ts` unconditionally `readdirSync`'s these fixed legacy paths on every run, regardless of whether a user's config actually references any old-style per-item templates — so this now throws `ENOENT: no such file or directory, scandir '.../sonarr/includes/custom-formats'` and (with `STOP_ON_ERROR`) aborts the whole sync, for every config, even ones that already migrated to the new bundled templates.

This guards each legacy directory with the same `existsSync` check `loadLocalRecyclarrTemplate` already uses for its own template path, and treats a missing directory as "no legacy templates found" instead of a fatal error.

## Changes

- `src/recyclarr-importer.ts`: add an `existsSync` guard before each `readdirSync` in `loadRecyclarrTemplates`'s `fillMap`, matching the existing pattern in `loadLocalRecyclarrTemplate`.
- `src/recyclarr-importer.test.ts`: new regression test covering both the missing-directory case (no throw, empty map, `readdirSync` not called) and the existing-directory case (templates still load as before).

## Test plan

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (413/413 passing, including the 2 new tests)
- [x] Verified locally against a real Sonarr/Radarr config that hit this exact crash, using `recyclarrRevision` pinned to current `master` (`9faf65ff745d74ab906fd73cadaa25f08eb9d981`, where the legacy directories are already gone) — confirmed the sync now proceeds instead of crashing on the missing directory.

## Disclosure

This PR was prepared with [Claude Code](https://claude.com/claude-code) (model: Claude Sonnet 5), under my direction and review — I read through the diff, ran the full check suite myself, and take responsibility for the change. Commit is attributed accordingly via a `Co-authored-by` trailer.

## Summary by Sourcery

Handle missing legacy template include directories without crashing when loading Recyclarr templates.

Bug Fixes:
- Prevent ENOENT crashes in loadRecyclarrTemplates when legacy Sonarr/Radarr includes directories are absent.

Tests:
- Add regression tests verifying loadRecyclarrTemplates skips missing legacy directories and still loads templates when they exist.