### PR TITLE
fix: pin recyclarr templates to legacy includes

### DIFF
--- a/config.yml.template
+++ b/config.yml.template
@@ -1,7 +1,7 @@
 trashGuideUrl: https://github.com/TRaSH-Guides/Guides
 #trashRevision: master # Optional to specify sha
 recyclarrConfigUrl: https://github.com/recyclarr/config-templates
-#recyclarrRevision: master # Optional to specify sha
+#recyclarrRevision: 4ae377bb704fc7fd69a544ad04e91357e0b09f62 # Optional; default is this pin (legacy includes). Upstream master dropped them (Recyclarr v8).
 
 # Optional if you want to add custom formats locally
 #localCustomFormatsPath: ./custom/cfs

--- a/docs/docs/configuration/_include/config-file-sample.yml
+++ b/docs/docs/configuration/_include/config-file-sample.yml
@@ -2,9 +2,11 @@
 #trashGuideUrl: https://github.com/BlackDark/fork-TRASH-Guides
 #recyclarrConfigUrl: https://github.com/BlackDark/fork-recyclarr-configs
 
-# Optional: Specify a custom branch/revision (defaults to 'master')
+# Optional: Specify a custom branch/revision
+# trashRevision defaults to 'master'
+# recyclarrRevision defaults to pinned SHA with legacy includes/ (see issue #504)
 #trashRevision: master
-#recyclarrRevision: master
+#recyclarrRevision: 4ae377bb704fc7fd69a544ad04e91357e0b09f62 # default pin; upstream master dropped legacy includes/ (Recyclarr v8)
 
 # since v1.12.0. Optional. Enable for legacy configuration to clone full repos (trash, recyclarr) instead of sparse.
 # Default is false. Setting to true increases storage usage up to 10x.

--- a/docs/docs/configuration/config-file.md
+++ b/docs/docs/configuration/config-file.md
@@ -107,9 +107,12 @@ trashGuideUrl: https://github.com/your-org/fork-TRASH-Guides
 # Use a custom Recyclarr templates fork
 recyclarrConfigUrl: https://github.com/your-org/fork-recyclarr-configs
 
-# Optional: Specify a custom branch/revision (defaults to 'master')
+# Optional: Specify a custom branch/revision
+# trashRevision defaults to 'master'
+# recyclarrRevision defaults to a pinned SHA that still has legacy includes/
+# (upstream master removed them in Recyclarr v8 — see issue #504)
 trashRevision: main
-recyclarrRevision: develop
+recyclarrRevision: 4ae377bb704fc7fd69a544ad04e91357e0b09f62
 ```
 
 **Repository URL Changes:**

--- a/src/recyclarr-importer.test.ts
+++ b/src/recyclarr-importer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { DEFAULT_RECYCLARR_REVISION, resolveRecyclarrRevision } from "./recyclarr-importer";
+
+describe("resolveRecyclarrRevision", () => {
+  test("pins official repo to last includes-compatible revision when unset", () => {
+    // Regression for https://github.com/raydak-labs/configarr/issues/504
+    expect(resolveRecyclarrRevision(undefined, undefined)).toBe(DEFAULT_RECYCLARR_REVISION);
+    expect(resolveRecyclarrRevision(undefined, "https://github.com/recyclarr/config-templates")).toBe(DEFAULT_RECYCLARR_REVISION);
+  });
+
+  test("keeps explicit recyclarrRevision override", () => {
+    expect(resolveRecyclarrRevision("master", undefined)).toBe("master");
+    expect(resolveRecyclarrRevision("abc123", "https://github.com/recyclarr/config-templates")).toBe("abc123");
+  });
+
+  test("uses master for custom forks when revision unset", () => {
+    expect(resolveRecyclarrRevision(undefined, "https://github.com/example/fork-recyclarr-configs")).toBe("master");
+  });
+});

--- a/src/recyclarr-importer.ts
+++ b/src/recyclarr-importer.ts
@@ -8,14 +8,42 @@ import { cloneGitRepo, recyclarrRepoPaths } from "./util";
 
 const DEFAULT_RECYCLARR_GIT_URL = "https://github.com/recyclarr/config-templates";
 
+/**
+ * Last commit on recyclarr/config-templates that still ships the legacy
+ * includes/ fragment layout Configarr loads. Upstream v8 (merged into master
+ * on 2026-08-07) deleted those directories in favor of bundled starter templates.
+ * See https://github.com/raydak-labs/configarr/issues/504
+ */
+export const DEFAULT_RECYCLARR_REVISION = "4ae377bb704fc7fd69a544ad04e91357e0b09f62";
+
+export const resolveRecyclarrRevision = (recyclarrRevision?: string, recyclarrConfigUrl?: string): string => {
+  if (recyclarrRevision) {
+    return recyclarrRevision;
+  }
+
+  const gitUrl = recyclarrConfigUrl ?? DEFAULT_RECYCLARR_GIT_URL;
+  // Custom forks may not contain the pinned SHA; keep branch tip for those.
+  if (gitUrl !== DEFAULT_RECYCLARR_GIT_URL) {
+    return "master";
+  }
+
+  return DEFAULT_RECYCLARR_REVISION;
+};
+
 export const cloneRecyclarrTemplateRepo = async () => {
   logger.info(`Checking Recyclarr repo ...`);
 
   const rootPath = recyclarrRepoPaths.root;
   const applicationConfig = getConfig();
   const gitUrl = applicationConfig.recyclarrConfigUrl ?? DEFAULT_RECYCLARR_GIT_URL;
-  const revision = applicationConfig.recyclarrRevision ?? "master";
+  const revision = resolveRecyclarrRevision(applicationConfig.recyclarrRevision, applicationConfig.recyclarrConfigUrl);
   const sparseDisabled = applicationConfig.enableFullGitClone === true;
+
+  if (!applicationConfig.recyclarrRevision && gitUrl === DEFAULT_RECYCLARR_GIT_URL) {
+    logger.info(
+      `Using pinned Recyclarr config-templates revision ${DEFAULT_RECYCLARR_REVISION} (legacy includes/). Override with recyclarrRevision if needed.`,
+    );
+  }
 
   const cloneResult = await cloneGitRepo(rootPath, gitUrl, revision, {
     disabled: sparseDisabled,


### PR DESCRIPTION
## Summary
- Default `recyclarrRevision` for the official `recyclarr/config-templates` repo is now pinned to `4ae377bb704fc7fd69a544ad04e91357e0b09f62` — last master commit that still has `*/includes/` fragments Configarr loads
- Fixes #504 (ENOENT crash after Recyclarr v8 deleted those dirs on `master`)
- Explicit `recyclarrRevision` still wins; custom `recyclarrConfigUrl` forks still default to `master` (pin SHA may not exist there)
- Docs/template comments updated

## Test plan
- [x] `pnpm build && pnpm test && pnpm lint && pnpm typecheck`
- [ ] Run against Sonarr/Radarr config that uses recyclarr includes (e.g. `sonarr-v4-custom-formats-web-1080p`) without setting `recyclarrRevision`
- [ ] Confirm log line mentions pinned revision
- [ ] Confirm override `recyclarrRevision: master` still allowed (will break includes again — expected)

## Summary by Sourcery

Pin the default Recyclarr templates revision to the last legacy-includes-compatible commit, add a resolver utility with logging, and document and test the new default behavior.

New Features:
- Introduce configurable resolution of the Recyclarr templates revision based on optional recyclarrRevision and recyclarrConfigUrl settings.

Bug Fixes:
- Prevent crashes when upstream Recyclarr config-templates master removes legacy includes directories by pinning the default revision to the last includes-compatible commit.

Enhancements:
- Log when the official Recyclarr config-templates repository is using the pinned legacy-includes revision to make the behavior explicit.

Documentation:
- Update configuration docs and sample config files to describe the new default pinned recyclarrRevision and its rationale.

Tests:
- Add unit tests for resolveRecyclarrRevision to cover default pinning, explicit overrides, and custom fork behavior.